### PR TITLE
Run instance fix

### DIFF
--- a/eucaops/ec2ops.py
+++ b/eucaops/ec2ops.py
@@ -692,7 +692,7 @@ class EC2ops(Eutester):
         if image is None:
             images = self.ec2.get_all_images()
             for emi in images:
-                if re.match("emi",emi.name):
+                if re.match("emi",emi.id):
                     image = emi      
         if image is None:
             raise Exception("emi is None. run_instance could not auto find an emi?")   


### PR DESCRIPTION
The fix for EUCA-3517 [1] requires an update to eutester to use the correct image property (the name can be specified by a user)

[1] https://eucalyptus.atlassian.net/browse/EUCA-3517
