### PR TITLE
Allow using a specific EMI and add an output option to write a file Nagios can parse

### DIFF
--- a/testcases/cloud_user/instances/instancetest.py
+++ b/testcases/cloud_user/instances/instancetest.py
@@ -461,11 +461,13 @@ if __name__ == "__main__":
                                                   test instance functionality and features \
                                                   on a Eucalyptus Cloud.  For more information, \
                                                   please refer to https://github.com/hspencer77/eutester/wiki/instancetest.",
-                                     usage="%(prog)s --credpath=<path to creds> [--xml] [--emi=emi-id] [--tests=test1,..testN]")
+                                     usage="%(prog)s --credpath=<path to creds> [--xml|nagios] [--emi=emi-id] [--tests=test1,..testN]")
     parser.add_argument('--credpath',
                         help="path to user credentials", default=".eucarc")
     parser.add_argument('--xml', 
                         help="to provide JUnit style XML output", action="store_true", default=False)
+    parser.add_argument('--nagios',
+                        help="to provide Nagios parsable output", action="store_true", default=False)
     parser.add_argument('--emi',
                         help="specific emi to run", default=False)
     parser.add_argument('--tests', nargs='+', 
@@ -483,9 +485,22 @@ if __name__ == "__main__":
             file = open("results/test-" + test + "result.xml", "w")
             result = xmlrunner.XMLTestRunner(file).run(InstanceBasics(test))
             file.close()
+        elif args.nagios:
+            try:
+                os.mkdir("/tmp/results")
+            except OSError:
+                pass   
+            file = open("/tmp/results/test-" + test + "-result.txt", "w")
+            result = unittest.TextTestRunner(verbosity=2).run(InstanceBasics(test))
         else:
             result = unittest.TextTestRunner(verbosity=2).run(InstanceBasics(test))
         if result.wasSuccessful():
+            if args.nagios:
+                file.write("PASS\n")
+                file.close()
             pass
         else:
+            if args.nagios:
+                file.write("FAIL\n")
+                file.close()
             exit(1)


### PR DESCRIPTION
These commits have been used to help use the instancetest.py as part of a Nagios check on cloud availability.

First commit adds the option to specify a particular EMI with --emi <emi-id>. This is useful when running the basic instancetest.py on a regular basis as you may not want it to pick a random EMI. It defaults to the original behaviour of picking a random instance-store backed EMI.

The second commit adds an output option --nagios to output a PASS or a FAIL into /tmp/results. I parse this results file with a Nagios check script. I'm open to other ways to adapt that so it's useful in other tests. Perhaps using the --xml output and using something to parse the junit style xml output?
