### PR TITLE
Add basic jclouds test to Eutester4j

### DIFF
--- a/eutester4j/build.xml
+++ b/eutester4j/build.xml
@@ -1,78 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project name="Eutester4J" basedir="." default="clean-build">
-
+<project name="Eutester4J" basedir="." default="clean-build" xmlns:ivy="antlib:org.apache.ivy.ant">
 
     <property name="src.dir" value="com/eucalyptus/tests/awssdk"/>
     <property name="build.dir" value="build"/>
     <property name="classes.dir" value="${build.dir}/classes"/>
     <property name="deps.dir" value="dependencies"/>
     <property name="testng.output.dir" value="eutester4j_results"/>
-    <property name="testng.version" value="6.8"/>
-    <property name="testng-jar" value="${deps.dir}/testng-${testng.version}.jar"/>
-    <property name="log4j.version" value="1.2.17"/>
-    <property name="log4j-jar" value="${deps.dir}/log4j-${log4j.version}.jar"/>
-    <property name="aws.dir" value="${deps.dir}/aws-java-sdk"/>
     <property name="eucarc" value="eucarc"/>
     <property name="tests" value=""/>
 
-    <!-- download and ready testng and AWS JAVA SDK -->
+    <!-- download testng and AWS Java SDK -->
     <target name="download-deps">
         <mkdir dir="${deps.dir}"/>
-        <echo message="installing testng..."/>
-        <get src="http://testng.org/testng-${testng.version}.zip"
-             dest="${deps.dir}/testng-${testng.version}.zip"/>
-        <unzip src="${deps.dir}/testng-${testng.version}.zip" dest="${deps.dir}">
-            <patternset>
-                <include name="**/testng-${testng.version}.jar"/>
-            </patternset>
-            <mapper type="flatten"/>
-        </unzip>
-
-        <echo message="installing log4j..."/>
-        <get src="http://www.eng.lsu.edu/mirrors/apache/logging/log4j/${log4j.version}/log4j-${log4j.version}.zip"
-             dest="${deps.dir}/log4j-${log4j.version}.zip"/>
-        <unzip src="${deps.dir}/log4j-${log4j.version}.zip" dest="${deps.dir}">
-            <patternset>
-                <include name="**/log4j-${log4j.version}.jar"/>
-            </patternset>
-            <mapper type="flatten"/>
-        </unzip>
-
-        <echo message="installing aws java sdk..."/>
-        <get src="http://sdk-for-java.amazonwebservices.com/latest/aws-java-sdk.zip"
-             dest="${deps.dir}/aws-java-sdk.zip"/>
-        <unzip src="${deps.dir}/aws-java-sdk.zip" dest="${aws.dir}">
-            <patternset>
-                <include name="**/*.jar"/>
-            </patternset>
-            <mapper type="flatten"/>
-        </unzip>
+        <ivy:retrieve conf="default" pattern="${deps.dir}/[artifact]-[revision].[ext]"/>
     </target>
 
-    <!-- set classpath to include AWS java sdk, testng.jar and build location -->
+    <!-- set classpath to include dependencies and build output -->
     <path id="classpath">
-        <fileset dir="${aws.dir}">
-            <include name="**/*.jar"/>
+        <fileset dir="${deps.dir}">
+            <include name="*.jar"/>
         </fileset>
-        <pathelement location="${testng-jar}"/>
-        <dirset dir="${build.dir}">
-            <include name="**/classes"/>
-        </dirset>
-        <pathelement location="${log4j-jar}"/>
+        <pathelement path="${classes.dir}"/>
     </path>
 
-    <!-- delete build and resutls directories -->
+    <!-- delete build and results directories -->
     <target name="clean">
         <delete dir="${build.dir}"/>
         <delete dir="${deps.dir}"/>
     </target>
 
     <!-- delete build, results and dependencies directories -->
-    <target name="clean-all">
-        <delete dir="${build.dir}"/>
+    <target name="clean-all" depends="clean">
         <delete dir="${testng.output.dir}"/>
-        <delete dir="${deps.dir}"/>
     </target>
 
     <!-- compile all classes of src.dir -->
@@ -84,10 +43,11 @@
 
     <!-- compile all and run tests per testng.xml -->
     <target name="runTestNG" depends="compile">
-
         <taskdef name="testng" classname="org.testng.TestNGAntTask">
             <classpath>
-                <pathelement location="${testng-jar}"/>
+                <fileset dir="${deps.dir}">
+                    <include name="testng-*.jar"/>
+                </fileset>
             </classpath>
         </taskdef>
 

--- a/eutester4j/com/eucalyptus/tests/awssdk/Eutester4j.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/Eutester4j.java
@@ -91,8 +91,8 @@ class Eutester4j {
         s3 = getS3Client(ACCESS_KEY, SECRET_KEY, S3_ENDPOINT);
         IMAGE_ID = findImage();
         KERNEL_ID = findKernel();
-        RAMDISK_ID = finadRamdisk();
-        AVAILABILITY_ZONE = findAvalablityZone();
+        RAMDISK_ID = findRamdisk();
+        AVAILABILITY_ZONE = findAvailabilityZone();
         NAME_PREFIX = eucaUUID() + "-";
         print("Using resource prefix for test: " + NAME_PREFIX);
         print("Cloud Discovery Complete");
@@ -102,7 +102,11 @@ class Eutester4j {
         print("*****TEST NAME: " + testName);
     }
 
-	/**
+	public static void testInfo(Class testClass){
+		testInfo( testClass.getSimpleName() );
+	}
+
+  /**
 	 * create ec2 connection based with supplied accessKey and secretKey
 	 * 
 	 * @param accessKey
@@ -297,7 +301,84 @@ class Eutester4j {
 		}
 	}
 
-	public static String findImage() {
+	/**
+	 * Wait for instance steady state (no PENDING, no STOPPING, no SHUTTING-DOWN)
+	 */
+	public static void waitForInstances( final long timeout ) {
+		final long startTime = System.currentTimeMillis( );
+		withWhile:
+		while ( true ) {
+			if ( ( System.currentTimeMillis() - startTime ) > timeout ) {
+				throw new IllegalStateException( "Instance wait timed out" );
+			}
+			try {
+				Thread.sleep( 2000 );
+			} catch ( InterruptedException e ) {
+				Thread.currentThread().interrupt();
+			}
+			DescribeInstancesResult result = ec2.describeInstances( );
+			for ( final Reservation reservation : result.getReservations() ) {
+				for ( final Instance instance : reservation.getInstances() ) {
+					switch ( instance.getState().getCode( ) ) {
+						case 0:
+						case 32:
+						case 64:
+							continue withWhile;
+					}
+				}
+			}
+			break;
+		}
+	}
+
+	/**
+	 * Wait for volume steady state (no creating, no deleting)
+	 */
+	public static void waitForVolumes( final long timeout ) {
+		final long startTime = System.currentTimeMillis( );
+		withWhile:
+		while ( true ) {
+			if ( ( System.currentTimeMillis() - startTime ) > timeout ) {
+				throw new IllegalStateException( "Volume wait timed out" );
+			}
+			try {
+				Thread.sleep( 2000 );
+			} catch ( InterruptedException e ) {
+				Thread.currentThread().interrupt();
+			}
+			final DescribeVolumesResult result = ec2.describeVolumes( );
+			for ( final Volume volume : result.getVolumes() ) {
+				if ( "creating".equals( volume.getState( ) ) ||
+						"deleting".equals( volume.getState( ) ) ) continue withWhile;
+			}
+			break;
+		}
+	}
+
+	/**
+	 * Wait for snapshot steady state (no pending)
+	 */
+	public static void waitForSnapshots( final long timeout ) {
+		final long startTime = System.currentTimeMillis( );
+		withWhile:
+		while ( true ) {
+			if ( ( System.currentTimeMillis() - startTime ) > timeout ) {
+				throw new IllegalStateException( "Snapshot wait timed out" );
+			}
+			try {
+				Thread.sleep( 2000 );
+			} catch ( InterruptedException e ) {
+				Thread.currentThread().interrupt();
+			}
+			final DescribeSnapshotsResult result = ec2.describeSnapshots( );
+			for ( final Snapshot snapshot : result.getSnapshots() ) {
+				if ( "pending".equals( snapshot.getState( ) ) ) continue withWhile;
+			}
+			break;
+		}
+	}
+
+  public static String findImage() {
 		// Find an appropriate image to launch
 		final DescribeImagesResult imagesResult = ec2
 				.describeImages(new DescribeImagesRequest().withFilters(
@@ -327,7 +408,7 @@ class Eutester4j {
         return imagesResult.getImages().get(0).getKernelId();
     }
 
-    public static String finadRamdisk(){
+    public static String findRamdisk(){
         // Find an appropriate image to launch
         final DescribeImagesResult imagesResult = ec2
                 .describeImages(new DescribeImagesRequest()
@@ -341,7 +422,7 @@ class Eutester4j {
         return imagesResult.getImages().get(0).getRamdiskId();
     }
 
-	public static String findAvalablityZone() {
+	public static String findAvailabilityZone() {
 		// Find an AZ to use
 		final DescribeAvailabilityZonesResult azResult = ec2
 				.describeAvailabilityZones();
@@ -371,7 +452,7 @@ class Eutester4j {
 	 * @param name
 	 * @param desc
 	 */
-	public static void createSecurityGoup(String name, String desc) {
+	public static void createSecurityGroup( String name, String desc ) {
 		try {
 			CreateSecurityGroupRequest securityGroupRequest = new CreateSecurityGroupRequest(
 					name, desc);
@@ -424,7 +505,7 @@ class Eutester4j {
 	 * @param securityGroups
 	 */
 	public static void runInstances(String emi, String keyName,
-			String type, ArrayList<String> securityGroups, int minCount,
+			String type, List<String> securityGroups, int minCount,
 			int maxCount) {
 		RunInstancesRequest runInstancesRequest = new RunInstancesRequest()
 				.withInstanceType(type).withImageId(emi).withMinCount(minCount)
@@ -512,11 +593,58 @@ class Eutester4j {
 		DeleteKeyPairRequest deleteKeyPairRequest = new DeleteKeyPairRequest(
 				keyName);
 		ec2.deleteKeyPair(deleteKeyPairRequest);
-		print("Delted keypair: " + keyName);
+		print("Deleted keypair: " + keyName);
 	}
 
 	/**
-	 * 
+	 * Create a volume, returning the identifier.
+	 */
+	public static String createVolume( final String zone, final int size ) {
+		final String volumeId = ec2.createVolume(
+			new CreateVolumeRequest( )
+				.withAvailabilityZone( zone )
+				.withSize( size )
+		).getVolume( ).getVolumeId( );
+		print( "Created Volume: " + volumeId );
+		return volumeId;
+	}
+
+	public static void deleteVolume( final String volumeId ) {
+		ec2.deleteVolume( new DeleteVolumeRequest( ).withVolumeId( volumeId ) );
+		print( "Deleted Volume: " + volumeId );
+	}
+
+	/**
+	 * Create a snapshot, returning the identifier.
+	 */
+	public static String createSnapshot( final String volumeId, final String description ) {
+		final String snapshotId = ec2.createSnapshot(
+			new CreateSnapshotRequest( )
+				.withVolumeId( volumeId )
+				.withDescription( description )
+		).getSnapshot().getSnapshotId();
+		print( "Created Snapshot: " + snapshotId );
+		return snapshotId;
+  }
+
+	public static void deleteSnapshot( final String snapshotId ) {
+		ec2.deleteSnapshot( new DeleteSnapshotRequest( ).withSnapshotId( snapshotId ) );
+		print( "Deleted Snapshot: " + snapshotId );
+  }
+
+	public static String allocateElasticIP( ) {
+		final String ip = ec2.allocateAddress( ).getPublicIp( );
+		print( "Allocated Elastic IP: " + ip );
+		return ip;
+	}
+
+	public static void releaseElasticIP( final String ip ) {
+		ec2.releaseAddress( new ReleaseAddressRequest( ).withPublicIp( ip ) );
+		print( "Released Elastic IP: " + ip );
+  }
+
+	/**
+	 *
 	 * @return
 	 */
 	public static List<Instance> getLastlaunchedInstance() {

--- a/eutester4j/com/eucalyptus/tests/awssdk/Eutester4jTemplateTest.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/Eutester4jTemplateTest.java
@@ -65,7 +65,7 @@ public class Eutester4jTemplateTest {
         getCloudInfo();
 		
 		// create a security group
-		createSecurityGoup(securityGroup, "A Test Security Group");
+		createSecurityGroup( securityGroup, "A Test Security Group" );
 		DescribeSecurityGroupsRequest describeSecurityGroupsRequest = new DescribeSecurityGroupsRequest();
 		DescribeSecurityGroupsResult securityGroupsResult = ec2
 				.describeSecurityGroups(describeSecurityGroupsRequest);

--- a/eutester4j/com/eucalyptus/tests/awssdk/Eutester4jTest.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/Eutester4jTest.java
@@ -78,7 +78,7 @@ public class Eutester4jTest {
 //		ec2Endpoint = "http://ec2.us-west-1.amazonaws.com"; //AWS
 //		asEndpoint = "http://autoscaling.us-west-1.amazonaws.com"; //AWS
 
-		createSecurityGoup(secGroupName, secGroupDesc);
+		createSecurityGroup( secGroupName, secGroupDesc );
 		createKeyPair(keyName);
 		securityGroups.add(secGroupName);
 	}
@@ -153,7 +153,7 @@ public class Eutester4jTest {
 		int initialSize = secGroups.size();
 	
 		try {
-			createSecurityGoup(name, desc);
+			createSecurityGroup( name, desc );
 			secGroups = describeSecurityGroups();
 			AssertJUnit.assertTrue(secGroups.size() > initialSize);
 		} catch (Exception e) {
@@ -172,7 +172,7 @@ public class Eutester4jTest {
 		String desc = eucaUUID();
 	
 		try {
-			createSecurityGoup(name, desc);
+			createSecurityGroup( name, desc );
 			
 			List<SecurityGroup> secGroups = describeSecurityGroups();
 			int initialSize = secGroups.size();

--- a/eutester4j/com/eucalyptus/tests/awssdk/JCloudsTest.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/JCloudsTest.java
@@ -1,0 +1,233 @@
+package com.eucalyptus.tests.awssdk;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
+import static com.eucalyptus.tests.awssdk.Eutester4j.*;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.domain.ComputeMetadata;
+import org.jclouds.domain.Location;
+import org.jclouds.ec2.EC2AsyncClient;
+import org.jclouds.ec2.EC2Client;
+import org.jclouds.ec2.domain.KeyPair;
+import org.jclouds.ec2.domain.PublicIpInstanceIdPair;
+import org.jclouds.ec2.domain.SecurityGroup;
+import org.jclouds.ec2.domain.Snapshot;
+import org.jclouds.ec2.domain.Volume;
+import org.jclouds.logging.log4j.config.Log4JLoggingModule;
+import org.jclouds.rest.RestContext;
+import org.testng.annotations.Test;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+
+/**
+ * Tests for JClouds library
+ *
+ * @see <a href="http://www.jclouds.org/">jclouds.org</a>
+ * @see <a href="http://github.com/jclouds/">jclouds on github.com</a>
+ */
+public class JCloudsTest {
+  private static final String securityGroupName   = "SECURITY-GROUP-" + eucaUUID();
+  private static final String keyName             = "KEYPAIR-" + eucaUUID();
+  private static final String snapshotDescription = "Test Snapshot";
+  private static final String eucalyptusRegion    = "eucalyptus";
+
+  /**
+   * Test jclouds functionality related to EC2 describe actions.
+   */
+  @Test
+  public void testDescribeEC2( ) throws Exception {
+    testInfo( this.getClass( ) );
+    getCloudInfo( );
+
+    final List<Runnable> cleanup = new ArrayList<Runnable>();
+    try {
+      // create resources for use in test and register clean up tasks
+      cleanup.add( new Runnable() {
+        @Override
+        public void run() {
+          deleteKeyPair( keyName );
+        }
+      } );
+      cleanup.add( new Runnable() {
+        @Override
+        public void run() {
+          deleteSecurityGroup( securityGroupName );
+        }
+      } );
+      print( "Creating security group…" );
+      createSecurityGroup( securityGroupName, "A Test Security Group" );
+      print( "Creating key pair…" );
+      createKeyPair( keyName );
+      print( "Creating volume…" );
+      final String volumeId = createVolume( findAvailabilityZone(), 1 );
+      print( "Waiting for volume availability…" );
+      waitForVolumes( TimeUnit.MINUTES.toMillis( 1 ) );
+      cleanup.add( new Runnable() {
+        @Override
+        public void run() {
+          deleteVolume( volumeId );
+        }
+      } );
+      print( "Creating snapshot…" );
+      final String snapshotId = createSnapshot( volumeId, snapshotDescription );
+      print( "Waiting for snapshot availability…" );
+      waitForSnapshots( TimeUnit.MINUTES.toMillis( 1 ) );
+      cleanup.add( new Runnable() {
+        @Override
+        public void run() {
+          deleteSnapshot( snapshotId );
+        }
+      } );
+      print( "Allocating elastic ip…" );
+      final String ip = allocateElasticIP( );
+      cleanup.add( new Runnable() {
+        @Override
+        public void run() {
+          releaseElasticIP( ip );
+        }
+      } );
+      runInstances( findImage( ), keyName, "m1.small", Collections.singletonList( securityGroupName ), 1, 1 );
+      final String id = getLastlaunchedInstance().get(0).getInstanceId();
+      cleanup.add( new Runnable() {
+        @Override
+        public void run() {
+          terminateInstances( Collections.singletonList( id ) );
+          waitForInstances( TimeUnit.MINUTES.toMillis( 3 ) );
+        }
+      } );
+
+      // begin jclouds test
+      final ContextBuilder builder = initContextBuilder( ACCESS_KEY, SECRET_KEY );
+      final ComputeService compute = builder.buildView( ComputeServiceContext.class ).getComputeService( );
+      final EC2Client ec2Client = builder.<RestContext<EC2Client, EC2AsyncClient>>build( ).getApi( );
+
+      print( "Calling listAssignableLocations…" );
+      final Set<? extends Location> locations = compute.listAssignableLocations();
+      print( "Total Number of Locations = " + locations.size() );
+      print( "Retrieved locations:" + locations );
+      boolean foundRegion = false;
+      boolean foundZone = false;
+      for (final Location location: locations) {
+        print( "\t" + location );
+        switch ( location.getScope( ) ) {
+          case REGION:
+            foundRegion = true;
+            break;
+          case ZONE:
+            foundZone = true;
+            break;
+        }
+      }
+      assertThat( foundRegion, "Region not found" );
+      assertThat( foundZone, "Availability zone not found" );
+
+      print( "Calling listImages…" );
+      final Set<? extends ComputeMetadata> images = compute.listImages();
+      print( "Total Number of Images = " + images.size() );
+      assertThat( !images.isEmpty(), "Images not found" );
+      for (final ComputeMetadata image: images) {
+        print( "\t" + image );
+      }
+
+      print( "Calling listNodes…" );
+      final Set<? extends ComputeMetadata> nodes = compute.listNodes();
+      print( "Total Number of Nodes = " + nodes.size() );
+      boolean foundInstance = false;
+      for (final ComputeMetadata node: nodes) {
+        print( "\t" + node );
+        if ( id.equals( node.getProviderId() ) ) {
+          foundInstance = true;
+        }
+      }
+      assertThat( foundInstance, "Instance ("+id+") not found" );
+
+      print( "Calling describeKeyPairsInRegion…" );
+      final Set<KeyPair> keyPairs = ec2Client.getKeyPairServices().describeKeyPairsInRegion( eucalyptusRegion );
+      print( "Total Number of KeyPairs = " + keyPairs.size() );
+      boolean foundKeyPair = false;
+      for (final KeyPair keyPair: keyPairs) {
+        print( "\t" + keyPair );
+        if ( keyName.equals( keyPair.getKeyName() ) ) {
+          foundKeyPair = true;
+        }
+      }
+      assertThat( foundKeyPair, "KeyPair ("+keyName+") not found" );
+
+      print( "Calling describeSecurityGroupsInRegion…" );
+      final Set<SecurityGroup> securityGroups = ec2Client.getSecurityGroupServices().describeSecurityGroupsInRegion( eucalyptusRegion );
+      print( "Total Number of SecurityGroups = " + securityGroups.size() );
+      boolean foundSecurityGroup= false;
+      for (final SecurityGroup securityGroup: securityGroups) {
+        print( "\t" + securityGroup );
+        if ( securityGroupName.equals( securityGroup.getName( ) ) ) {
+          foundSecurityGroup = true;
+        }
+      }
+      assertThat( foundSecurityGroup, "SecurityGroup ("+ securityGroupName +") not found" );
+
+      print( "Calling describeAddressesInRegion…" );
+      final Set<PublicIpInstanceIdPair> ips = ec2Client.getElasticIPAddressServices().describeAddressesInRegion( eucalyptusRegion );
+      print( "Total Number of IPS = " + ips.size() );
+      boolean foundElasticIP = false;
+      for (final PublicIpInstanceIdPair ipp: ips) {
+        print( "\t" + ipp.getPublicIp() );
+        if ( ip.equals( ipp.getPublicIp() ) ) {
+          foundElasticIP = true;
+        }
+      }
+      assertThat( foundElasticIP, "Elastic IP ("+ ip +") not found" );
+
+      print( "Calling describeSnapshotsInRegion…" );
+      final Set<Snapshot> snapshots = ec2Client.getElasticBlockStoreServices().describeSnapshotsInRegion( eucalyptusRegion );
+      print( "Total Number of Snapshots = " + snapshots.size() );
+      boolean foundSnapshot = false;
+      for (final Snapshot snapshot: snapshots) {
+        print( "\t" + snapshot );
+        if ( snapshotId.equals( snapshot.getId() ) ) {
+          foundSnapshot = true;
+        }
+      }
+      assertThat( foundSnapshot, "Snapshot ("+ snapshotId +") not found" );
+
+      print( "Calling describeVolumesInRegion…" );
+      final Set<Volume> volumes = ec2Client.getElasticBlockStoreServices().describeVolumesInRegion( eucalyptusRegion );
+      print( "Total Number of Volumes = " + volumes.size() );
+      boolean foundVolume = false;
+      for (final Volume volume: volumes) {
+        print( "\t" + volume );
+        if ( volumeId.equals( volume.getId() ) ) {
+          foundVolume = true;
+        }
+      }
+      assertThat( foundVolume, "Volume ("+ volumeId +") not found" );
+
+      print( "Test complete" );
+    } finally {
+      Collections.reverse( cleanup );
+      for ( final Runnable runnable : cleanup ) {
+        try {
+          runnable.run( );
+        } catch ( Exception e ) {
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+
+  private static ContextBuilder initContextBuilder( String accessKeyIdentifier, String secretKey ) {
+    final Iterable<Module> modules = ImmutableSet.<Module>of( new Log4JLoggingModule( ) );
+    final Properties properties = new Properties();
+    properties.setProperty( Constants.PROPERTY_ENDPOINT, EC2_ENDPOINT );
+    return ContextBuilder.newBuilder( "ec2" )
+        .credentials( accessKeyIdentifier, secretKey )
+        .modules( modules )
+        .overrides( properties );
+  }
+}

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingEC2ReferenceValidation.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingEC2ReferenceValidation.java
@@ -62,7 +62,7 @@ public class TestAutoScalingEC2ReferenceValidation {
 			final String securityGroupName = NAME_PREFIX + "EC2ReferenceTest";
 			print("Creating a security group for test use: "
 					+ securityGroupName);
-            createSecurityGoup(securityGroupName, securityGroupName);
+            createSecurityGroup( securityGroupName, securityGroupName );
 			cleanupTasks.add(new Runnable() {
 				@Override
 				public void run() {

--- a/eutester4j/ivy.xml
+++ b/eutester4j/ivy.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivy-module version="2.0">
+    <info organisation="com.eucalyptus" module="eutester4j"/>
+    <configurations defaultconfmapping="default"/>
+    <dependencies>
+        <!-- core dependencies -->
+        <dependency org="log4j" name="log4j" rev="1.2.17"/>
+        <dependency org="org.testng" name="testng" rev="6.8.5"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk" rev="1.4.5"/>
+
+        <!-- jclouds dependencies -->
+        <dependency org="org.jclouds" name="jclouds-compute" rev="1.6.0-rc.1"/>
+        <dependency org="org.jclouds.api" name="ec2" rev="1.6.0-rc.1"/>
+        <dependency org="org.jclouds.driver" name="jclouds-log4j" rev="1.6.0-rc.1"/>
+    </dependencies>
+</ivy-module>

--- a/eutester4j/testng.xml
+++ b/eutester4j/testng.xml
@@ -26,6 +26,7 @@
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingDescribePolicyAlarms"/>
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingDescribeTags"/>
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingInstanceLifecycle"/>
+            <class name="com.eucalyptus.tests.awssdk.TestAutoScalingInstanceProfile"/>
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingLaunchAndTerminate"/>
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingMetricsManagement"/>
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingMetricsSubmission"/>
@@ -40,6 +41,7 @@
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingEc2InstanceHealthMonitoring"/>
             <class name="com.eucalyptus.tests.awssdk.TestAutoScalingEC2ReferenceValidation"/>
             <class name="com.eucalyptus.tests.awssdk.TestEC2DescribeInstanceStatus"/>
+            <class name="com.eucalyptus.tests.awssdk.TestEC2InstanceProfile"/>
             <class name="com.eucalyptus.tests.awssdk.TestEC2RunInstancesClientToken"/>
         </classes>
     </test>
@@ -57,6 +59,11 @@
             <class name="com.eucalyptus.tests.awssdk.TestIAMRoleManagement"/>
             <!-- TestSTSAssumeRole must be run as non-admin user -->
             <!-- <class name="com.eucalyptus.tests.awssdk.TestSTSAssumeRole"/> -->
+        </classes>
+    </test>
+    <test name="JClouds">
+        <classes>
+            <class name="com.eucalyptus.tests.awssdk.JCloudsTest"/>
         </classes>
     </test>
     <test name="Eutester4j_Sanity_Test">


### PR DESCRIPTION
A jclouds test is added with coverage of basic describe functionality.
Supporting methods are added to Eutester4j for working with volumes,
snapshots and elastic ips. The Eutester4l build is updated to use Ivy
for dependency retrieval.
