### PR TITLE
If instance user is not root, try to execute commands at instance using sudo/su by default

### DIFF
--- a/eutester/euinstance.py
+++ b/eutester/euinstance.py
@@ -356,7 +356,7 @@ class EuInstance(Instance, TaggedResource):
         if ( self.verbose is True ):
             self.debugmethod(msg)
 
-    def sys(self, cmd, verbose=True, code=None, try_non_root_exec=None, enable_debug=False, timeout=120):
+    def sys(self, cmd, verbose=True, code=None, try_non_root_exec=True, enable_debug=False, timeout=120):
         '''
         Issues a command against the ssh connection to this instance
         Returns a list of the lines from stdout+stderr as a result of the command


### PR DESCRIPTION
Currently none of the commands in euinstance.py are tried to be run using sudo/su. So in case your instance user is not root, the tests will fail miserably. 
