### PR TITLE
Change order of cleanup in cloudwatch test. The fix moves delete autosca...

### DIFF
--- a/eutester4j/TestSuites/CI-run.xml
+++ b/eutester4j/TestSuites/CI-run.xml
@@ -48,6 +48,13 @@
             <class name="com.eucalyptus.tests.awssdk.TestIAMRoleManagement"/>
         </classes>
     </test>
+    <test name="ELB_Tests">
+        <classes>
+            <class name="com.eucalyptus.tests.awssdk.TestAutoScalingELBAddRemoveInstances"/>
+            <class name="com.eucalyptus.tests.awssdk.TestAutoScalingELBInstanceHealthMonitoring"/>
+            <class name="com.eucalyptus.tests.awssdk.TestAutoScalingELBReferenceValidation"/>
+        </classes>>
+    </test>
     <!--<test name="Walrus_Tests">-->
         <!--<classes>-->
             <!--<class name="com.eucalyptus.tests.awssdk.BasicWalrusTest"/>-->

--- a/testcases/cloud_user/cloudwatch/cloudwatchbasics.py
+++ b/testcases/cloud_user/cloudwatch/cloudwatchbasics.py
@@ -45,8 +45,8 @@ class CloudWatchBasics(EutesterTestCase):
 
 
     def clean_method(self):
-        self.tester.cleanup_artifacts()
         self.cleanUpAutoscaling()
+        self.tester.cleanup_artifacts()
         self.tester.delete_keypair(self.keypair)
         pass
 


### PR DESCRIPTION
...ling to happen before resource cleanup. This should alleviate the AS group failing to delete. What was happening is that since resource cleanup was done first the AS instances were shutting down and a new scaling activity was in progress to respawn those and at that time the clean up of the AS group was attempted thus the failure due to scaling activity in progress.

This change also adds ELB tests to E4j CI run as they are stable and we are post 3.4.2 now.
