### PR TITLE
Fix pluralization of "walrus"

### DIFF
--- a/testcases/cloud_admin/install_euca.py
+++ b/testcases/cloud_admin/install_euca.py
@@ -188,8 +188,8 @@ class Install(EutesterTestCase):
         clcs = self.tester.get_component_machines("clc")
         if len(clcs) > 1:
             clcs[0].sys("euca_conf --register-cloud -C eucalyptus -P eucalyptus -H " + clcs[1].hostname)
-        walrii = self.tester.get_component_machines("ws")
-        for walrus in walrii:
+        walruses = self.tester.get_component_machines("ws")
+        for walrus in walruses:
             clcs[0].sys("euca_conf --register-walrus -C walrus -P walrus -H " + walrus.hostname)
         ccs = self.tester.get_component_machines("cc")
         registered_clusters = {1:None, 2:None,3:None,4:None,5:None,6:None,7:None,8:None}


### PR DESCRIPTION
The word "walrii", meant to be a plural form of "walrus", sparks some interesting discussions of how that word may have come to be:

Using an "i" to pluralize a noun that ends in "us" employs the rule that applies to many Latin masculine nouns of the second declension use.  But for that to yield "walrii" the singular form would have to be
"walrius", which conflicts with the singular form "walrus" used in the for loop on the very next line.

"Virii" gets away with this because it isn't clear how to properly pluralize a second declension neuter mass noun.  "Walrus" isn't a mass noun, though, so it doesn't get to use that trick.

Finally, "walrus" is Dutch.  We shouldn't be pluralizing it like a Latin word.  8^)
