### PR TITLE
Fix bucket tests not failing

### DIFF
--- a/testcases/cloud_user/s3/bucket_tests.py
+++ b/testcases/cloud_user/s3/bucket_tests.py
@@ -91,9 +91,11 @@ class BucketTestSuite(EutesterTestCase):
             if should_fail:
                 self.fail("Should have caught exception for bad bucket name: " + bad_bucket)
         
-        for bad_bucket in ["bucket123/", "bucket..123", "bucket&123", "bucket*123", "/bucket123", "bucket.", ".bucket"]:
+        for bad_bucket in ["bucket123/", "bucket..123", "bucket&123", "bucket*123",  "bucket."]:
             test_creating_bucket_invalid_names(self.bucket_prefix + bad_bucket)
 
+        for bad_bucket in ["/bucket123", ".bucket"]:
+            test_creating_bucket_invalid_names(bad_bucket + "-" + self.bucket_prefix)
 
         """
         Test creating bucket with null name


### PR DESCRIPTION
The  `test_bucket_get_put_delete` was not failing (in the correct place):

```
try:
   self.tester.create_bucket(bad_bucket)
   should_fail = True
   ...
   if should_fail:
        fail("Should have caught exception...")
except:
    self.tester.debug("Correctly caught the exception...")
```

This is because `fail` throws `AssertionError` - which is then happily caught with "Correctly caught the exception.."

Other thing here is the fix for deleting the bucket, if it was created. This tried to delete the bucket with the name of it, but `tester.delete_bucket()` eats bucket objects instead. 

Was a good opportunity also to get rid of some code duplication. 
