### PR TITLE
Test cleanup

### DIFF
--- a/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingELBAddRemoveInstances.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingELBAddRemoveInstances.java
@@ -91,8 +91,9 @@ public class TestAutoScalingELBAddRemoveInstances {
             as.createAutoScalingGroup(new CreateAutoScalingGroupRequest()
                     .withAutoScalingGroupName(groupName)
                     .withLaunchConfigurationName(configName)
-                    .withMinSize(1)
+                    .withMinSize(0)
                     .withMaxSize(1)
+                    .withDesiredCapacity(1)
                     .withAvailabilityZones(AVAILABILITY_ZONE)
                     .withLoadBalancerNames(loadBalancerName)
             );

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingELBInstanceHealthMonitoring.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingELBInstanceHealthMonitoring.java
@@ -19,10 +19,8 @@
  ************************************************************************/
 package com.eucalyptus.tests.awssdk;
 
-import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest;
-import com.amazonaws.services.autoscaling.model.CreateLaunchConfigurationRequest;
-import com.amazonaws.services.autoscaling.model.DeleteLaunchConfigurationRequest;
-import com.amazonaws.services.autoscaling.model.SetDesiredCapacityRequest;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.autoscaling.model.*;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.amazonaws.services.elasticloadbalancing.model.ConfigureHealthCheckRequest;
 import com.amazonaws.services.elasticloadbalancing.model.HealthCheck;
@@ -149,6 +147,22 @@ public class TestAutoScalingELBInstanceHealthMonitoring {
             final String replacementInstanceId = (String) waitForInstances(timeout, 1, groupName,true).get(0);
             assertThat(!replacementInstanceId.equals(instanceId), "Instance not replaced");
 
+            // Set desired capacity below minimum exception expected
+            print("Setting desired capacity to 0 (below minimum should fail) for group: " + groupName);
+            try {
+                as.setDesiredCapacity(new SetDesiredCapacityRequest()
+                        .withAutoScalingGroupName(groupName)
+                        .withDesiredCapacity(0));
+                assertThat(false, "Setting Desired Capacity below min should fail");
+            } catch (AmazonServiceException e) {
+                print("Expected error returned: " + e);
+            }
+
+            // Set desired minimum size to zero
+            as.updateAutoScalingGroup(new UpdateAutoScalingGroupRequest()
+                    .withAutoScalingGroupName(groupName)
+                    .withMinSize(0));
+            print("Changed Minimum size to Zero");
             // Set desired capacity to zero
             print("Setting desired capacity to 0 for group: " + groupName);
             as.setDesiredCapacity(new SetDesiredCapacityRequest()

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingMetricsSubmission.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestAutoScalingMetricsSubmission.java
@@ -86,7 +86,7 @@ public class TestAutoScalingMetricsSubmission {
             );
 
             // Enable single metric
-            print("Enabling GroupMinSize metric for group: " + groupName);
+            print("Enabling GroupMaxSize metric for group: " + groupName);
             as.enableMetricsCollection(new EnableMetricsCollectionRequest()
                     .withAutoScalingGroupName(groupName)
                     .withMetrics("GroupMaxSize")

--- a/testcases/cloud_user/elb/elb_policy_basics.py
+++ b/testcases/cloud_user/elb/elb_policy_basics.py
@@ -58,7 +58,7 @@ class LoadBalancerPolicy(EutesterTestCase):
         zones = self.tester.ec2.get_all_zones()
         self.zone = random.choice(zones).name
         self.load_balancer_port = 80
-        self.lb_name="test-" + str(time.time())
+        self.lb_name="test-" + str(int(time.time()))
         self.load_balancer = self.tester.create_load_balancer(zones=[self.zone],
                                                               name=self.lb_name,
                                                               load_balancer_port=self.load_balancer_port)

--- a/testcases/cloud_user/elb/loadbalancing.py
+++ b/testcases/cloud_user/elb/loadbalancing.py
@@ -57,11 +57,11 @@ class LoadBalancing(EutesterTestCase):
         self.tester.poll_count = 120
 
         ### Add and authorize a group for the instance
-        self.group = self.tester.add_group(group_name="group-" + str(time.time()))
+        self.group = self.tester.add_group(group_name="group-" + str(int(time.time())))
         self.tester.authorize_group_by_name(group_name=self.group.name )
         self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp" )
         ### Generate a keypair for the instance
-        self.keypair = self.tester.add_keypair( "keypair-" + str(time.time()))
+        self.keypair = self.tester.add_keypair( "keypair-" + str(int(time.time())))
         self.keypath = '%s/%s.pem' % (os.curdir, self.keypair.name)
         ### Get an image
         self.image = self.args.emi
@@ -82,7 +82,7 @@ class LoadBalancing(EutesterTestCase):
                                                                           image=self.image)
 
         self.load_balancer = self.tester.create_load_balancer(zones=[self.zone],
-                                                              name="test-" + str(time.time()),
+                                                              name="test-" + str(int(time.time())),
                                                               load_balancer_port=self.load_balancer_port)
         assert isinstance(self.load_balancer, LoadBalancer)
         self.tester.register_lb_instances(self.load_balancer.name,

--- a/testcases/cloud_user/elb/stickiness_test.py
+++ b/testcases/cloud_user/elb/stickiness_test.py
@@ -58,11 +58,11 @@ class StickinessBasics(EutesterTestCase):
         self.tester.poll_count = 120
 
         ### Add and authorize a group for the instance
-        self.group = self.tester.add_group(group_name="group-" + str(time.time()))
+        self.group = self.tester.add_group(group_name="group-" + str(int(time.time())))
         self.tester.authorize_group_by_name(group_name=self.group.name)
         self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp")
         ### Generate a keypair for the instance
-        self.keypair = self.tester.add_keypair("keypair-" + str(time.time()))
+        self.keypair = self.tester.add_keypair("keypair-" + str(int(time.time())))
         self.keypath = '%s/%s.pem' % (os.curdir, self.keypair.name)
 
         ### Get an image
@@ -84,7 +84,7 @@ class StickinessBasics(EutesterTestCase):
                                                                            image=self.image)
 
         self.load_balancer = self.tester.create_load_balancer(zones=[self.zone],
-                                                              name="test-" + str(time.time()),
+                                                              name="test-" + str(int(time.time())),
                                                               load_balancer_port=self.load_balancer_port)
         assert isinstance(self.load_balancer, LoadBalancer)
         self.tester.register_lb_instances(self.load_balancer.name,


### PR DESCRIPTION
Eutester - remove seconds from time stamp appended to resource names for ELB tests now we have no underscore in ELB name for DNS compatibility.

Eutester4J - New test case to cover setting desired capacity below minimum (new in 4.0), modified tests that set desired capacity to zero by ensuring minimum size is zero first.
