### PR TITLE
fixed assertion - replaced assertEqual with assert

### DIFF
--- a/testcases/cloud_user/s3/bucket_tests.py
+++ b/testcases/cloud_user/s3/bucket_tests.py
@@ -157,8 +157,8 @@ class BucketTestSuite(EutesterTestCase):
             if bucket_obj:
                 self.fail("Should have caught exception for creating bucket with empty-string name.")
         except S3ResponseError as e:
-            self.assertEqual(e.status, 405, 'Expected response status code to be 405, actual status code is ' + str(e.status))
-            self.assertTrue(re.search("MethodNotAllowed", e.code), "Incorrect exception returned when creating bucket with null name.")
+            assert (e.status == 405), 'Expected response status code to be 405, actual status code is ' + str(e.status)
+            assert (re.search("MethodNotAllowed", e.code)), "Incorrect exception returned when creating bucket with null name."
         except Exception, e:
             self.tester.debug("Failed due to EUCA-7059 " + str(e))
 


### PR DESCRIPTION
Fixes the following error in the test unit,

`
TESTUNIT FAILED: test_bucket_get_put_deleteTraceback (most recent call last):
  File "eutester/eutestcase.py", line 275, in run
    ret = self.method()
  File "/root/testing/eutester/testcases/cloud_user/s3/bucket_tests.py", line 108, in test_bucket_get_put_delete
    self.assertEqual(e.status, 405, 'Expected response status code to be 405, actual status code is ' + str(e.status))
  File "/usr/local/lib/python2.7/unittest/case.py", line 514, in assertEqual
    assertion_func = self._getAssertEqualityFunc(first, second)
  File "/usr/local/lib/python2.7/unittest/case.py", line 495, in _getAssertEqualityFunc
    asserter = self._type_equality_funcs.get(type(first))
AttributeError: 'BucketTestSuite' object has no attribute '_type_equality_funcs'
`
