### PR TITLE
Adds restart for eucalyptus-cloud after riakcs config

### DIFF
--- a/testcases/cloud_admin/riak-cs/install_riak_cs.py
+++ b/testcases/cloud_admin/riak-cs/install_riak_cs.py
@@ -8,6 +8,8 @@ import sys
 
 # Install and configure Riak CS for Eucalyptus
 # /install_riak_cs.py --config /path/to/config --password foobar --template-path "/path/to/templates/"
+from eutester.machine import Machine
+
 
 class InstallRiak(EutesterTestCase):
     def __init__(self):
@@ -19,7 +21,7 @@ class InstallRiak(EutesterTestCase):
         self.parser.add_argument("--riak-cs-port", default="9090")
         self.get_args()
         # Setup basic eutester object
-        self.tester = Eucaops( config_file=self.args.config,password=self.args.password)
+        self.tester = Eucaops(config_file=self.args.config, password=self.args.password, credpath=self.args.credpath)
 
     def clean_method(self):
         pass
@@ -65,19 +67,10 @@ class InstallRiak(EutesterTestCase):
                 key_contents = key.read()
                 cs_tester.debug("Uploaded Key contents: " + key_contents + "  Original:" + response_dict["id"])
                 assert key_contents == response_dict["id"]
-                
-                self.tester.info("Configuring OSG to use RiakCS backend")
-                self.tester.modify_property("objectstorage.providerclient","s3")
 
                 endpoint = machine.hostname + ":" + self.args.riak_cs_port
-                self.tester.info("Configuring OSG to use s3 endpoint: " + endpoint)
-                self.tester.modify_property("objectstorage.s3provider.s3endpoint", endpoint)
 
-                self.tester.info("Configuring OSG to use s3 access key: " + response_dict["key_id"])
-                self.tester.modify_property("objectstorage.s3provider.s3accesskey", response_dict["key_id"])
-
-                self.tester.info("Configuring OSG to use s3 secret key: " + response_dict["key_secret"][-4:])
-                self.tester.modify_property("objectstorage.s3provider.s3secretkey",response_dict["key_secret"])
+                self.configure_osg_for_riakcs(key_id=response_dict["key_id"], secret_key=response_dict["key_secret"], endpoint=endpoint)
 
         except IndexError as e:
             try:
@@ -87,7 +80,32 @@ class InstallRiak(EutesterTestCase):
             except IndexError as ex:
                 self.tester.info("No RIAK/WS component found in component specification. Skipping installation")
 
-            
+
+    def configure_osg_for_riakcs(self, key_id=None, secret_key=None, endpoint=None):
+        assert key_id is not None
+        assert secret_key is not None
+        assert endpoint is not None
+
+        self.tester.info("Configuring OSG to use RiakCS backend")
+        self.tester.modify_property("objectstorage.providerclient","riakcs")
+
+        self.tester.info("Configuring OSG to use s3 endpoint: " + endpoint)
+        self.tester.modify_property("objectstorage.s3provider.s3endpoint", endpoint)
+
+        self.tester.info("Configuring OSG to use s3 access key: " + key_id)
+        self.tester.modify_property("objectstorage.s3provider.s3accesskey", key_id)
+
+        self.tester.info("Configuring OSG to use s3 secret key: " + secret_key[-4:])
+        self.tester.modify_property("objectstorage.s3provider.s3secretkey", secret_key)
+
+        # Restart all OSG services to ensure they pick up the new config because walrus is the default provider
+        # Relates to EUCA-9421 fix
+        self.tester.info("Restarting the eucalyptus-cloud service on each OSG host to pickup new configuration")
+        for osg_host in self.tester.get_component_machines("osg"):
+            assert isinstance(osg_host, Machine)
+            self.tester.info("Restarting eucalyptus-cloud service on host: " + osg_host.hostname)
+            osg_host.sys("service eucalyptus-cloud restart")
+
 if __name__ == "__main__":
     testcase = InstallRiak()
     ### Use the list of tests passed from config/command line to determine what subset of tests to run


### PR DESCRIPTION
Also sets 'riakcs' rather than 's3' as provider.
