### PR TITLE
Make self.image instance of Image also when specific emi is given as a parameter

### DIFF
--- a/testcases/cloud_user/instances/instancetest.py
+++ b/testcases/cloud_user/instances/instancetest.py
@@ -48,7 +48,7 @@ class InstanceBasics(EutesterTestCase):
         self.keypair = self.tester.add_keypair("keypair-" + str(time.time()))
         self.keypath = '%s/%s.pem' % (os.curdir, self.keypair.name)
         if emi:
-            self.image = emi
+            self.image = self.tester.get_emi(emi=emi)
         else:
             self.image = self.tester.get_emi(root_device_type="instance-store", not_platform="windows")
         self.address = None


### PR DESCRIPTION
Without this change, if --emi parameter is given on command-line, self.image will be assigned the value of the --emi parameter i.e. a string. Then the tests will fail on BasicInstanceChecks on line 101:
`if self.image.virtualization_type == "paravirtual":`
