### PR TITLE
Make Churn test work also when run as non-admin.

### DIFF
--- a/testcases/cloud_user/instances/instancetest.py
+++ b/testcases/cloud_user/instances/instancetest.py
@@ -362,7 +362,11 @@ class InstanceBasics(EutesterTestCase):
                 executor.submit(self.tester.terminate_instances, future.result())
 
         def available_after_greater():
-            return self.tester.get_available_vms(zone=self.zone) >= available_instances_before
+            try:
+                return self.tester.get_available_vms(zone=self.zone) >= available_instances_before
+            except IndexError, e:
+                self.debug("Running as non-admin, skipping validation of available VMs.")
+                return True
         self.tester.wait_for_result(available_after_greater, result=True, timeout=360)
 
     def PrivateIPAddressing(self):


### PR DESCRIPTION
There is a similar handling of IndexError in the beginning of the test. Would be maybe better to push that handling inside the get_available_vms method to reduce amount of duplicate code. 

I still think that even without the final check of available VMs, the Churn test provides value also when run as non-admin.