### PR TITLE
Added Cloudformation Test Templates for 4.1 Testing

### DIFF
--- a/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-hvm-instanceprofile.json
+++ b/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-hvm-instanceprofile.json
@@ -1,0 +1,87 @@
+{
+
+    "AWSTemplateFormatVersion":"2010-09-09",
+
+    "Description":"Test Creation of AutoScaling Launch Configuration",
+
+    "Parameters": {
+        "EucaImageId": {
+            "Description":"Eucalyptus Machine Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaMonitor": {
+            "Description":"Enable/Disable Instance Monitoring",
+            "Type":"String",
+            "NoEcho":"True",
+            "Default":"True"
+        },
+
+        "EucaInstanceProfile": {
+            "Description":"Instance Profile",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "UserKeyPair": {
+            "Description":"User Key Pair",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "VmType": {
+            "Description":"Desired VM Type for Instances",
+            "Type":"String",
+            "NoEcho":"True"
+        }
+
+    },
+
+    "Resources" : {
+
+        "EucaLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "ImageId" : { "Ref":"EucaImageId" },
+                "InstanceType" : { "Ref" : "VmType" },
+                "IamInstanceProfile" : { "Ref" : "EucaInstanceProfile" },
+                "InstanceMonitoring" : { "Ref" : "EucaMonitor" },
+                "UserData" : { "Fn::Base64" : "#include https://get.docker.io" },
+                "SecurityGroups" : [
+                    { "Ref" : "EucaSecurityGroup" }
+                ],
+                "BlockDeviceMappings" : [
+                    {
+                      "DeviceName": "/dev/sdm",
+                      "Ebs" : { "VolumeSize" : "5", "DeleteOnTermination" : "true" }
+                    }
+                ],
+                "KeyName" : { "Ref" : "UserKeyPair" }
+            }
+        },
+
+        "EucaSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "Security Group for AutoScaling Launch Configuration",
+                    "SecurityGroupIngress" : [
+                        {
+                            "IpProtocol" : "tcp",
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp" : "0.0.0.0/0"
+                        }
+                    ]
+                }
+        }
+
+    },
+
+    "Outputs" : {
+        "AutoScalingLaunchConfiguration" : {
+            "Description" : "AutoScaling Launch Configuration Name",
+            "Value" : { "Ref" : "EucaLaunchConfig" }
+        }
+    }
+}

--- a/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-hvm.json
+++ b/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-hvm.json
@@ -1,0 +1,80 @@
+{
+
+    "AWSTemplateFormatVersion":"2010-09-09",
+
+    "Description":"Test Creation of AutoScaling Launch Configuration",
+
+    "Parameters": {
+        "EucaImageId": {
+            "Description":"Eucalyptus Machine Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaMonitor": {
+            "Description":"Enable/Disable Instance Monitoring",
+            "Type":"String",
+            "NoEcho":"True",
+            "Default":"True"
+        },
+
+        "UserKeyPair": {
+            "Description":"User Key Pair",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "VmType": {
+            "Description":"Desired VM Type for Instances",
+            "Type":"String",
+            "NoEcho":"True"
+        }
+
+    },
+
+    "Resources" : {
+
+        "EucaLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "ImageId" : { "Ref":"EucaImageId" },
+                "InstanceType" : { "Ref" : "VmType" },
+                "InstanceMonitoring" : { "Ref" : "EucaMonitor" },
+                "UserData" : { "Fn::Base64" : "#include https://get.docker.io" },
+                "SecurityGroups" : [
+                    { "Ref" : "EucaSecurityGroup" }
+                ],
+                "BlockDeviceMappings" : [
+                    {
+                      "DeviceName": "/dev/sdm",
+                      "Ebs" : { "VolumeSize" : "5", "DeleteOnTermination" : "true" }
+                    }
+                ],
+                "KeyName" : { "Ref" : "UserKeyPair" }
+            }
+        },
+
+        "EucaSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "Security Group for AutoScaling Launch Configuration",
+                    "SecurityGroupIngress" : [
+                        {
+                            "IpProtocol" : "tcp",
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp" : "0.0.0.0/0"
+                        }
+                    ]
+                }
+        }
+
+    },
+
+    "Outputs" : {
+        "AutoScalingLaunchConfiguration" : {
+            "Description" : "AutoScaling Launch Configuration Name",
+            "Value" : { "Ref" : "EucaLaunchConfig" }
+        }
+    }
+}

--- a/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-paravirt-instanceprofile.json
+++ b/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-paravirt-instanceprofile.json
@@ -1,0 +1,101 @@
+{
+
+    "AWSTemplateFormatVersion":"2010-09-09",
+
+    "Description":"Test Creation of AutoScaling Launch Configuration",
+
+    "Parameters": {
+        "EucaImageId": {
+            "Description":"Eucalyptus Machine Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaKernelId": {
+            "Description":"Eucalyptus Kernel Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaRamdiskId": {
+            "Description":"Eucalyptus Ramdisk Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaMonitor": {
+            "Description":"Enable/Disable Instance Monitoring",
+            "Type":"String",
+            "NoEcho":"True",
+            "Default":"True"
+        },
+
+        "EucaInstanceProfile": {
+            "Description":"Instance Profile",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "UserKeyPair": {
+            "Description":"User Key Pair",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "VmType": {
+            "Description":"Desired VM Type for Instances",
+            "Type":"String",
+            "NoEcho":"True"
+        }
+
+    },
+
+    "Resources" : {
+
+        "EucaLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "ImageId" : { "Ref":"EucaImageId" },
+                "KernelId" : { "Ref":"EucaKernelId" },
+                "RamDiskId" : { "Ref":"EucaRamdiskId" },
+                "IamInstanceProfile" : { "Ref" : "EucaInstanceProfile" },
+                "InstanceType" : { "Ref" : "VmType" },
+                "InstanceMonitoring" : { "Ref" : "EucaMonitor" },
+                "UserData" : { "Fn::Base64" : "#include https://get.docker.io" },
+                "SecurityGroups" : [
+                    { "Ref" : "EucaSecurityGroup" }
+                ],
+                "BlockDeviceMappings" : [
+                    {
+                      "DeviceName": "/dev/sdm",
+                      "Ebs" : { "VolumeSize" : "5", "DeleteOnTermination" : "true" }
+                    }
+                ],
+                "KeyName" : { "Ref" : "UserKeyPair" }
+            }
+        },
+
+        "EucaSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "Security Group for AutoScaling Launch Configuration",
+                    "SecurityGroupIngress" : [
+                        {
+                            "IpProtocol" : "tcp",
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp" : "0.0.0.0/0"
+                        }
+                    ]
+                }
+        }
+
+    },
+
+    "Outputs" : {
+        "AutoScalingLaunchConfiguration" : {
+            "Description" : "AutoScaling Launch Configuration Name",
+            "Value" : { "Ref" : "EucaLaunchConfig" }
+        }
+    }
+}

--- a/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-paravirt.json
+++ b/testcases/cloud_user/cloudformation/tempalates/cfn-as-launchconfig-paravirt.json
@@ -1,0 +1,94 @@
+{
+
+    "AWSTemplateFormatVersion":"2010-09-09",
+
+    "Description":"Test Creation of AutoScaling Launch Configuration",
+
+    "Parameters": {
+        "EucaImageId": {
+            "Description":"Eucalyptus Machine Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaKernelId": {
+            "Description":"Eucalyptus Kernel Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaRamdiskId": {
+            "Description":"Eucalyptus Ramdisk Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "EucaMonitor": {
+            "Description":"Enable/Disable Instance Monitoring",
+            "Type":"String",
+            "NoEcho":"True",
+            "Default":"True"
+        },
+
+        "UserKeyPair": {
+            "Description":"User Key Pair",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "VmType": {
+            "Description":"Desired VM Type for Instances",
+            "Type":"String",
+            "NoEcho":"True"
+        }
+
+    },
+
+    "Resources" : {
+
+        "EucaLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "ImageId" : { "Ref":"EucaImageId" },
+                "KernelId" : { "Ref":"EucaKernelId" },
+                "RamDiskId" : { "Ref":"EucaRamdiskId" },
+                "InstanceType" : { "Ref" : "VmType" },
+                "InstanceMonitoring" : { "Ref" : "EucaMonitor" },
+                "UserData" : { "Fn::Base64" : "#include https://get.docker.io" },
+                "SecurityGroups" : [
+                    { "Ref" : "EucaSecurityGroup" }
+                ],
+                "BlockDeviceMappings" : [
+                    {
+                      "DeviceName": "/dev/sdm",
+                      "Ebs" : { "VolumeSize" : "5", "DeleteOnTermination" : "true" }
+                    }
+                ],
+                "KeyName" : { "Ref" : "UserKeyPair" }
+            }
+        },
+
+        "EucaSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "Security Group for AutoScaling Launch Configuration",
+                    "SecurityGroupIngress" : [
+                        {
+                            "IpProtocol" : "tcp",
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp" : "0.0.0.0/0"
+                        }
+                    ]
+                }
+        }
+
+    },
+
+    "Outputs" : {
+        "AutoScalingLaunchConfiguration" : {
+            "Description" : "AutoScaling Launch Configuration Name",
+            "Value" : { "Ref" : "EucaLaunchConfig" }
+        }
+    }
+}

--- a/testcases/cloud_user/cloudformation/tempalates/cfn-coreos-as.json
+++ b/testcases/cloud_user/cloudformation/tempalates/cfn-coreos-as.json
@@ -1,0 +1,155 @@
+{
+
+    "AWSTemplateFormatVersion":"2010-09-09",
+
+    "Description":"Deploy CoreOS Cluster",
+
+    "Parameters": {
+        "CoreOSImageId": {
+            "Description":"CoreOS Image Id",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "UserKeyPair": {
+            "Description":"User Key Pair",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "ClusterSize": {
+            "Description":"Desired CoreOS Cluster Size",
+            "Type":"Number",
+            "NoEcho":"True"
+        },
+
+        "VmType": {
+            "Description":"Desired VM Type for Instances",
+            "Type":"String",
+            "NoEcho":"True"
+        },
+
+        "AcctId": {
+            "Description":"IAM Account Id of User",
+            "Type":"String",
+            "NoEcho":"True"
+        }
+    },
+
+    "Resources" : {
+        "CoreOsGroup" : {
+            "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "Properties" : {
+                "AvailabilityZones" : [ "<availability-zone>" ],
+                "LaunchConfigurationName" : { "Ref" : "CoreOsLaunchConfig" },
+                "MinSize" : { "Ref" : "ClusterSize" },
+                "MaxSize" : { "Ref" : "ClusterSize" } 
+            }
+        },
+
+        "CoreOsLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "ImageId" : { "Ref":"CoreOSImageId" },
+                "InstanceType" : { "Ref" : "VmType" },
+                "UserData" : { "Fn::Base64" : { "Fn::Join" : ["",[
+                    "#cloud-config","\n",
+                    "coreos:","\n",
+                    "  etcd:","\n",
+                    "    discovery: https://discovery.etcd.io/<token>","\n",
+                    "    addr: $private_ipv4:4001","\n",
+                    "    peer-addr: $private_ipv4:7001","\n",
+                    "  units:","\n",
+                    "    - name: format-ephemeral.service","\n",
+                    "      command: start","\n",
+                    "      content: |","\n",
+                    "        [Unit]","\n",
+                    "        Description=Formats the ephemeral drive","\n",
+                    "        [Service]","\n",
+                    "        Type=oneshot","\n",
+                    "        RemainAfterExit=yes","\n",
+                    "        ExecStart=/usr/sbin/wipefs -f /dev/vdb","\n",
+                    "        ExecStart=/usr/sbin/mkfs.btrfs -f /dev/vdb","\n",
+                    "    - name: var-lib-docker.mount","\n",
+                    "      command: start","\n",
+                    "      content: |","\n",
+                    "        [Unit]","\n",
+                    "        Description=Mount ephemeral to /var/lib/docker","\n",
+                    "        Requires=format-ephemeral.service","\n",
+                    "        Before=docker.service","\n",
+                    "        [Mount]","\n",
+                    "        What=/dev/vdb","\n",
+                    "        Where=/var/lib/docker","\n",
+                    "        Type=btrfs","\n",
+                    "    - name: etcd.service","\n",
+                    "      command: start","\n",
+                    "    - name: fleet.service","\n",
+                    "      command: start","\n" ]]}
+                },
+                "SecurityGroups" : [
+                    { "Ref" : "CoreOsSecurityGroup" }
+                ],
+                "KeyName" : { "Ref" : "UserKeyPair" }
+            }
+        },
+
+        "CoreOsSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "Security Group for CoreOS Cluster",
+                    "SecurityGroupIngress" : [
+                        {
+                            "IpProtocol" : "tcp",
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp" : "0.0.0.0/0"
+                        }
+                    ]
+                }
+        },
+
+        "CoreOsSecurityGroupIngress1": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+                "Properties": {
+                    "IpProtocol" : "tcp",
+                    "FromPort" : "4001",
+                    "ToPort" : "4001",
+                    "GroupName": {
+                        "Ref": "CoreOsSecurityGroup"
+                    },
+                    "SourceSecurityGroupName" : {
+                        "Ref" : "CoreOsSecurityGroup"
+                    },
+                    "SourceSecurityGroupOwnerId" : {
+                        "Ref" : "AcctId"
+                    }
+                }
+        },
+
+        "CoreOsSecurityGroupIngress2": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+                "Properties": {
+                    "IpProtocol" : "tcp",
+                    "FromPort" : "7001",
+                    "ToPort" : "7001",
+                    "SourceSecurityGroupName" : {
+                        "Ref" : "CoreOsSecurityGroup"
+                    },
+                    "GroupName": {
+                        "Ref": "CoreOsSecurityGroup"
+                    },
+                    "SourceSecurityGroupOwnerId" : {
+                        "Ref" : "AcctId"
+                    }
+                }
+        }
+
+    },
+
+    "Outputs" : {
+        "AutoScalingGroup" : {
+            "Description" : "AutoScaling Group Name",
+            "Value" : { "Ref" : "CoreOsGroup" }
+        }
+    }
+}

--- a/testcases/cloud_user/cloudformation/tempalates/cfn-ubuntu-docker.json
+++ b/testcases/cloud_user/cloudformation/tempalates/cfn-ubuntu-docker.json
@@ -1,0 +1,65 @@
+{
+
+    "AWSTemplateFormatVersion" : "2010-09-09",
+
+    "Description" : "Cloudformation Example => Run instance with userdata in security group",
+
+    "Parameters": {
+        "UbuntuImageId": {
+            "Description":"Ubuntu Image id",
+            "Type":"String",
+            "NoEcho":"False"
+        },
+
+        "UserKeyPair": {
+            "Description":"User Key Pair",
+            "Type":"String",
+            "NoEcho":"False"
+        }
+    },
+
+    "Resources" : {
+        "DockerSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription" : "Security Group with Ingress Rule for DockerInstance",
+                    "SecurityGroupIngress" : [
+                        {
+                            "IpProtocol" : "tcp",
+                            "FromPort" : "22",
+                            "ToPort" : "22",
+                            "CidrIp" : "0.0.0.0/0"
+                        }
+                    ]
+                }
+        },
+
+        "DockerInstance": {
+            "Type": "AWS::EC2::Instance",
+                "Properties": {
+                    "ImageId" : { "Ref":"UbuntuImageId" },
+                    "InstanceType" : "m2.xlarge",
+                    "UserData" : { "Fn::Base64" : "#include https://get.docker.io" },
+                    "SecurityGroups" : [
+                        { "Ref" : "DockerSecurityGroup" }
+                    ],
+            "KeyName" : { "Ref" : "UserKeyPair" }
+            }
+        }
+    },
+
+    "Outputs" : {
+        "InstanceId" : {
+            "Description" : "InstanceId of the newly created EC2 instance",
+            "Value" : { "Ref" : "DockerInstance" }
+        },
+        "AZ" : {
+            "Description" : "Availability Zone of the newly created EC2 instance",
+            "Value" : { "Fn::GetAtt" : [ "DockerInstance", "AvailabilityZone" ] }
+        },
+        "PublicIP" : {
+            "Description" : "Public IP address of the newly created EC2 instance",
+            "Value" : { "Fn::GetAtt" : [ "DockerInstance", "PublicIp" ] }
+        }
+    }
+}


### PR DESCRIPTION
Per @tbeckham request, provided the cloudformation templates I use on several clouds.

I used the following type of images:
- [Ubuntu HVM Cloud Image](http://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-disk1.img)
- [Ubuntu Paravirt Cloud Image](http://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64.tar.gz)
- [CoreOS Image](http://beta.release.core-os.net/amd64-usr/current/coreos_production_ami_image.bin.bz2) - I also did [a blog on this one](http://blogs.mindspew-age.com/2014/08/28/using-eucalyptus-4-0-1-cloudformation-to-deploy-a-coreos-docker-cluster/)
