### PR TITLE
Updates to e4j IAM tests

### DIFF
--- a/eutester4j/com/eucalyptus/tests/awssdk/TestIAMInstanceProfileManagement.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestIAMInstanceProfileManagement.java
@@ -66,7 +66,7 @@ public class TestIAMInstanceProfileManagement {
                                 .withInstanceProfileName(profileName));
                 assertThat(getProfileResult.getInstanceProfile() != null, "Expected profile");
                 assertThat(profileName.equals(getProfileResult.getInstanceProfile().getInstanceProfileName()), "Unexpected profile name");
-                assertThat("/path".equals(getProfileResult.getInstanceProfile().getPath()), "Unexpected profile path");
+                assertThat("/path/".equals(getProfileResult.getInstanceProfile().getPath()), "Unexpected profile path");
                 assertThat(getProfileResult.getInstanceProfile().getRoles() == null || getProfileResult.getInstanceProfile().getRoles().isEmpty(), "Unexpected roles");
             }
 

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestIAMInstanceProfiles.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestIAMInstanceProfiles.java
@@ -64,7 +64,7 @@ public class TestIAMInstanceProfiles {
                                 .withInstanceProfileName(profileName));
                 assertThat(getProfileResult.getInstanceProfile() != null, "Expected profile");
                 assertThat(profileName.equals(getProfileResult.getInstanceProfile().getInstanceProfileName()), "Unexpected profile name");
-                assertThat("/path".equals(getProfileResult.getInstanceProfile().getPath()), "Unexpected profile path");
+                assertThat("/path/".equals(getProfileResult.getInstanceProfile().getPath()), "Unexpected profile path");
                 assertThat(getProfileResult.getInstanceProfile().getRoles() == null || getProfileResult.getInstanceProfile().getRoles().isEmpty(), "Unexpected roles");
             }
 

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestIAMRoleManagement.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestIAMRoleManagement.java
@@ -76,9 +76,9 @@ public class TestIAMRoleManagement {
                                 .withRoleName(roleName));
                 assertThat(getRoleResult.getRole() != null, "Expected role");
                 assertThat(roleName.equals(getRoleResult.getRole().getRoleName()), "Unexpected role name");
-                assertThat("/path".equals(getRoleResult.getRole().getPath()), "Unexpected role path");
+                assertThat("/path/".equals(getRoleResult.getRole().getPath()), "Unexpected role path");
                 assertThat(getRoleResult.getRole().getAssumeRolePolicyDocument() != null &&
-                        getRoleResult.getRole().getAssumeRolePolicyDocument().contains("sts:AssumeRole"), "Expected assume role policy document");
+                        getRoleResult.getRole().getAssumeRolePolicyDocument().contains("AssumeRole"), "Expected assume role policy document");
                 assertThat(getRoleResult.getRole().getArn() != null, "Expected ARN");
                 assertThat(getRoleResult.getRole().getCreateDate() != null, "Expected created date");
             }
@@ -133,9 +133,9 @@ public class TestIAMRoleManagement {
                                 .withRoleName(roleName));
                 assertThat(getRoleResult.getRole() != null, "Expected role");
                 assertThat(roleName.equals(getRoleResult.getRole().getRoleName()), "Unexpected role name");
-                assertThat("/path".equals(getRoleResult.getRole().getPath()), "Unexpected role path");
+                assertThat("/path/".equals(getRoleResult.getRole().getPath()), "Unexpected role path");
                 assertThat(getRoleResult.getRole().getAssumeRolePolicyDocument() != null &&
-                        getRoleResult.getRole().getAssumeRolePolicyDocument().contains("sts:assumerole"), "Expected assume role policy document");
+                        getRoleResult.getRole().getAssumeRolePolicyDocument().contains("assumerole"), "Expected assume role policy document");
                 assertThat(getRoleResult.getRole().getArn() != null, "Expected ARN");
                 assertThat(getRoleResult.getRole().getCreateDate() != null, "Expected created date");
             }


### PR DESCRIPTION
Update IAM tests profile path by adding trailing "/". The trailing "/" was added as part of EUCA-9467. Also policy document is updated since the policy doc returned has changed and no longer contains "sts:" in the action.