### PR TITLE
Fix DNS service detection and get hostname for DNS service issue

### DIFF
--- a/testcases/cloud_admin/install_euca.py
+++ b/testcases/cloud_admin/install_euca.py
@@ -340,14 +340,14 @@ class Install(EutesterTestCase):
             self.tester = Eucaops(config_file=self.args.config_file, password=self.args.password)
         self.tester.modify_property("bootstrap.webservices.use_dns_delegation", "true")
         self.tester.modify_property("bootstrap.webservices.use_instance_dns", "true")
-        enabled_ufs = self.tester.service_manager.get_enabled_osg()
+        enabled_dns = self.tester.service_manager.get_enabled_dns()
         if self.args.dnsdomain:
             self.tester.modify_property("system.dns.dnsdomain", self.args.dnsdomain)
         else:
-            hostname = enabled_ufs.machine.sys('hostname')[0].split(".")[0]
+            hostname = self.tester.get_machine_by_ip(enabled_dns.hostname).sys('hostname')[0].split(".")[0]
             domain = hostname + ".autoqa.qa1.eucalyptus-systems.com"
             self.tester.modify_property("system.dns.dnsdomain", domain)
-        self.tester.modify_property("system.dns.nameserveraddress", enabled_ufs.hostname)
+        self.tester.modify_property("system.dns.nameserveraddress", enabled_dns.hostname)
 
     def clean_method(self):
         pass


### PR DESCRIPTION
I was using get_osg method before since that basically gets the UFS service, however in trying to fix an issue with getting hostname that way I found get_enabled_dns which will be better. This is  DnsService object so I am using get_machine_by_ip to get the machine and use some sys to get the hostname. I tested this on my setup.