### PR TITLE
Fix for ELB stickiness test

### DIFF
--- a/eucaops/ec2ops.py
+++ b/eucaops/ec2ops.py
@@ -5167,7 +5167,6 @@ disable_root: false"""
         if error_msg:
             raise Exception(error_msg)
 
-
     def create_web_servers(self, keypair, group, zone, port=80, count=2, image=None, filename="test-file", cookiename="test-cookie"):
         if not image:
             image = self.get_emi(root_device_type="instance-store", not_location="loadbalancer", not_platform="windows")
@@ -5182,12 +5181,14 @@ disable_root: false"""
                 ## Debian based Linux
                 instance.sys("apt-get update", code=0)
                 instance.sys("apt-get install -y apache2", code=0)
+                instance.sys("ln -s /etc/apache2/mods-available/usertrack.load /etc/apache2/mods-enabled/usertrack.load")
                 try:
                     instance.sys("echo \"" + instance.id +"\" > /var/www/html/" + filename, code=0)
                 except:
                     instance.sys("echo \"" + instance.id +"\" > /var/www/" + filename, code=0)
                 instance.sys("echo \"CookieTracking on\" >> /etc/apache2/apache2.conf")
                 instance.sys("echo CookieName " + cookiename +" >> /etc/apache2/apache2.conf")
+                instance.sys("service apache2 restart")
             except eutester.sshconnection.CommandExitCodeException, e:
                 ### Enterprise Linux
                 instance.sys("yum install -y httpd", code=0)

--- a/testcases/cloud_user/elb/stickiness_test.py
+++ b/testcases/cloud_user/elb/stickiness_test.py
@@ -129,8 +129,10 @@ class StickinessBasics(EutesterTestCase):
         self.tester.set_lb_policy(lb_name=self.load_balancer.name, lb_port=80, policy_name=acpolicy)
         self.debug("Testing App Cookie stickiness")
         responses = self.GenerateRequests()
-        host = responses[0]
-        for response in responses:
+        # since we use the same cookie name on the backing elb instances, the first contacts with the ELB can possibly
+        # result in hitting different back ends. After the first 2 calls they should all ony go to 1 backend.
+        host = responses[2]
+        for response in responses[2:]:
             if response != host:
                 raise Exception(
                     "Expected same response due to app cookie stickiness policy. Got initial response: " + host +


### PR DESCRIPTION
 Our default test image is now ubuntu. For a webserver we use apache2. Apache2 needs to have usertrack module loaded (as it is not a default) for cookies to work.