### PR TITLE
Use complex listener for ELB with SSL listener

### DIFF
--- a/eucaops/elbops.py
+++ b/eucaops/elbops.py
@@ -301,7 +301,7 @@ class ELBops(Eutester):
 
     def add_lb_listener(self, lb_name, listener):
         self.debug("adding listener")
-        self.elb.create_load_balancer_listeners(name=lb_name, listeners=[listener])
+        self.elb.create_load_balancer_listeners(name=lb_name, complex_listeners=[listener])
 
     def remove_lb_listener(self, lb_name, port):
         self.debug("removing listener")

--- a/testcases/cloud_user/elb/ssl_termination.py
+++ b/testcases/cloud_user/elb/ssl_termination.py
@@ -108,7 +108,7 @@ class SSLTermination(EutesterTestCase):
 
         """create a new listener on HTTPS port 443 and remove listener on port 80"""
         cert_arn = self.tester.get_server_cert(self.cert_name).arn
-        listener = (443, 80, "HTTPS", cert_arn)
+        listener = (443, 80, "HTTPS", "HTTP", cert_arn)
         self.tester.add_lb_listener(lb_name=self.load_balancer.name, listener=listener)
         self.tester.remove_lb_listener(lb_name=self.load_balancer.name, port=self.load_balancer_port)
 


### PR DESCRIPTION
In 4.2 we have to be sure to specify instance protocol when using HTTPS listener on front end when not using backend authentication.