### PR TITLE
The one with all the ELB refactorings

### DIFF
--- a/eucaops/__init__.py
+++ b/eucaops/__init__.py
@@ -439,7 +439,6 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
                 tb = self.get_traceback()
                 failcount +=1
                 failmsg += str(tb) + "\nError#:"+ str(failcount)+ ":" + str(e)+"\n"
-
         if launch_configurations:
             try:
                 self.cleanup_launch_configs()
@@ -447,7 +446,6 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
                 tb = self.get_traceback()
                 failcount +=1
                 failmsg += str(tb) + "\nError#:"+ str(failcount)+ ":" + str(e)+"\n"
-
 
         for key,array in self.test_resources.iteritems():
             for item in array:
@@ -476,13 +474,6 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
             failmsg += "\nFound " + str(failcount) + " number of errors while cleaning up. " \
                                                      "See above"
             raise Exception(failmsg)
-        if launch_configurations:
-            try:
-                self.cleanup_launch_configs()
-            except Exception, e:
-                tb = self.get_traceback()
-                failcount +=1
-                failmsg += str(tb) + "\nError#:"+ str(failcount)+ ":" + str(e)+"\n"
 
     def cleanup_load_balancers(self, lbs=None):
         """
@@ -496,6 +487,31 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
                 self.delete_load_balancers(self.test_resources['load_balancers'])
             except KeyError:
                 self.debug("No loadbalancers to delete")
+
+    def cleanup_autoscaling_groups(self, asg_list=None):
+        """
+        This will attempt to delete auto scaling groups listed in test_resources['auto-scaling-groups']
+        """
+        ### clear all ASGs
+        if asg_list:
+            self.delete_autoscaling_groups(asg_list)
+        else:
+            try:
+                self.delete_autoscaling_groups(self.test_resources['auto-scaling-groups'])
+            except KeyError:
+                self.debug("Auto scaling group list is empty")
+
+    def cleanup_launch_configs(self, lc_list=None):
+        """
+        This will attempt to delete launch configs listed in test_resources['launch-configurations']
+        """
+        if lc_list:
+            self.delete_launch_configs(lc_list)
+        else:
+            try:
+                self.delete_launch_configs(self.test_resources['launch-configurations'])
+            except KeyError:
+                self.debug("Launch configuration list is empty")
 
     def cleanup_addresses(self, ips=None):
         """
@@ -511,7 +527,6 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
 
         while addresses:
             self.release_address(addresses.pop())
-
 
     def cleanup_test_snapshots(self,snaps=None, clean_images=False, add_time_per_snap=10,
                                wait_for_valid_state=120, base_timeout=180):
@@ -541,9 +556,6 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
                                         base_timeout=base_timeout,
                                         add_time_per_snap=add_time_per_snap,
                                         wait_for_valid_state=wait_for_valid_state)
-
-
-
 
     def clean_up_test_volumes(self, volumes=None, min_timeout=180, timeout_per_vol=30):
         """
@@ -627,7 +639,7 @@ class Eucaops(EC2ops,S3ops,IAMops,STSops,CWops, ASops, ELBops, CFNops):
         if euvolumes:
             self.delete_volumes(euvolumes, timeout=timeout)
 
-                    
+
     def get_current_resources(self,verbose=False):
         '''
         Return a dictionary with all known resources the system has. Optional pass the verbose=True

--- a/eucaops/ec2ops.py
+++ b/eucaops/ec2ops.py
@@ -467,6 +467,15 @@ disable_root: false"""
             return False
         return True
 
+    def gracefully_delete_group(self, group):
+        try:
+            if group.delete():
+                self.debug("Deleted group " + group.name)
+                return True
+        except EC2ResponseError, ec2re:
+            self.debug(ec2re.error_message)
+            return False
+
     def check_group(self, group_name):
         """
         Check if a group with group_name exists in the system

--- a/eucaops/iamops.py
+++ b/eucaops/iamops.py
@@ -642,16 +642,24 @@ class IAMops(Eutester):
         return cert
 
     def delete_server_cert(self, cert_name):
-        self.debug("deleting server certificate: " + cert_name)
+        self.debug("Deleting server certificate: " + cert_name)
         self.euare.delete_server_cert(cert_name)
-        if (cert_name) in str(self.euare.get_all_server_certs()):
+        certs = self.list_server_certs()
+        if certs and cert_name in certs[0].values():
             raise Exception("certificate " + cert_name + " not deleted.")
 
+    def delete_all_server_certs(self):
+        self.debug("Deleting all server certificates")
+        certs = self.list_server_certs()
+        for cert in certs:
+            self.delete_server_cert(cert['server_certificate_name'])
+        return
+
     def list_server_certs(self, path_prefix='/', marker=None, max_items=None):
-        self.debug("listing server certificates")
+        self.debug("Listing server certificates")
         certs = self.euare.list_server_certs(path_prefix=path_prefix, marker=marker, max_items=max_items)
         self.debug(certs)
-        return certs
+        return certs['list_server_certificates_response']['list_server_certificates_result']['server_certificate_metadata_list']
 
     def create_login_profile(self, user_name, password, delegate_account=None):
         self.debug("Creating login profile for: " + user_name + " with password: " + password)

--- a/testcases/cloud_user/autoscaling/autoscaling.py
+++ b/testcases/cloud_user/autoscaling/autoscaling.py
@@ -56,7 +56,7 @@ class AutoScalingBasics(EutesterTestCase):
         ### Add and authorize a group for the instance
         self.group = self.tester.add_group(group_name="group-" + str(time.time()))
         self.tester.authorize_group_by_name(group_name=self.group.name )
-        self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp" )
+        self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp")
 
         ### Generate a keypair for the instance
         self.keypair = self.tester.add_keypair( "keypair-" + str(time.time()))
@@ -69,10 +69,10 @@ class AutoScalingBasics(EutesterTestCase):
         self.asg = None
 
     def clean_method(self):
-        if self.asg:
-            self.tester.wait_for_result(self.gracefully_delete, True)
-            self.tester.delete_as_group(self.asg.name, force=True)
         self.tester.cleanup_artifacts()
+        if self.tester.test_resources["security-groups"]:
+            for group in self.tester.test_resources["security-groups"]:
+                self.tester.wait_for_result(self.tester.gracefully_delete_group, True, timeout=60, group=group)
 
     def AutoScalingBasics(self):
         ### create launch configuration

--- a/testcases/cloud_user/elb/loadbalancing.py
+++ b/testcases/cloud_user/elb/loadbalancing.py
@@ -54,42 +54,62 @@ class LoadBalancing(EutesterTestCase):
             self.tester = ELBops( credpath=self.args.credpath, region=self.args.region)
         else:
             self.tester = Eucaops( credpath=self.args.credpath, config_file=self.args.config,password=self.args.password)
-        self.tester.poll_count = 120
 
-        ### Add and authorize a group for the instance
-        self.group = self.tester.add_group(group_name="group-" + str(int(time.time())))
-        self.tester.authorize_group_by_name(group_name=self.group.name )
-        self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp" )
-        ### Generate a keypair for the instance
-        self.keypair = self.tester.add_keypair( "keypair-" + str(int(time.time())))
+        # test resource hash
+        self.test_hash = str(int(time.time()))
+
+        # Add and authorize a group for the instances
+        self.group = self.tester.add_group(group_name="group-" + self.test_hash)
+        self.tester.authorize_group_by_name(group_name=self.group.name)
+        self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp")
+        self.tester.authorize_group_by_name(group_name=self.group.name, port=80, protocol="tcp")
+
+        # Generate a keypair for the instances
+        self.keypair = self.tester.add_keypair("keypair-" + self.test_hash)
         self.keypath = '%s/%s.pem' % (os.curdir, self.keypair.name)
-        ### Get an image
+
+        # User data file
+        self.user_data = "./testcases/cloud_user/elb/test_data/webserver_user_data.sh"
+
+        # Get an image
         self.image = self.args.emi
         if not self.image:
             self.image = self.tester.get_emi()
 
-        ### Populate available zones
+        # Populate available zones
         zones = self.tester.ec2.get_all_zones()
         self.zone = random.choice(zones).name
 
+        # create base load balancer
         self.load_balancer_port = 80
-
-        (self.web_servers, self.filename) = self.tester.create_web_servers(keypair=self.keypair,
-                                                                          group=self.group,
-                                                                          zone=self.zone,
-                                                                          port=self.load_balancer_port,
-                                                                          filename='instance-name',
-                                                                          image=self.image)
-
         self.load_balancer = self.tester.create_load_balancer(zones=[self.zone],
-                                                              name="test-" + str(int(time.time())),
+                                                              name="elb-" + self.test_hash,
                                                               load_balancer_port=self.load_balancer_port)
         assert isinstance(self.load_balancer, LoadBalancer)
-        self.tester.register_lb_instances(self.load_balancer.name,
-                                          self.web_servers.instances)
+
+        # create autoscaling group of webservers that register to the load balancer
+        self.count = 2
+        (self.web_servers) = self.tester.create_as_webservers(name=self.test_hash,
+                                                              keypair=self.keypair.name,
+                                                              group=self.group.name,
+                                                              zone=self.zone,
+                                                              image=self.image.id,
+                                                              count=self.count,
+                                                              user_data=self.user_data,
+                                                              load_balancer=self.load_balancer.name)
+
+        # web servers scaling group
+        self.asg = self.tester.describe_as_group(name="asg-"+self.test_hash)
+
+        # wait until scaling instances are InService with the load balancer before continuing - 5 min timeout
+        assert self.tester.wait_for_result(self.tester.wait_for_lb_instances, True, timeout=300,
+                                           lb=self.load_balancer.name, number=self.count)
 
     def clean_method(self):
         self.tester.cleanup_artifacts()
+        if self.tester.test_resources["security-groups"]:
+            for group in self.tester.test_resources["security-groups"]:
+                self.tester.wait_for_result(self.tester.gracefully_delete_group, True, timeout=60, group=group)
 
     def GenerateRequests(self):
         """

--- a/testcases/cloud_user/elb/stickiness_test.py
+++ b/testcases/cloud_user/elb/stickiness_test.py
@@ -55,44 +55,61 @@ class StickinessBasics(EutesterTestCase):
         else:
             self.tester = Eucaops(credpath=self.args.credpath, config_file=self.args.config,
                                   password=self.args.password)
-        self.tester.poll_count = 120
+        # test resource hash
+        self.test_hash = str(int(time.time()))
 
-        ### Add and authorize a group for the instance
-        self.group = self.tester.add_group(group_name="group-" + str(int(time.time())))
+        # Add and authorize a group for the instances
+        self.group = self.tester.add_group(group_name="group-" + self.test_hash)
         self.tester.authorize_group_by_name(group_name=self.group.name)
         self.tester.authorize_group_by_name(group_name=self.group.name, port=-1, protocol="icmp")
-        ### Generate a keypair for the instance
-        self.keypair = self.tester.add_keypair("keypair-" + str(int(time.time())))
+        self.tester.authorize_group_by_name(group_name=self.group.name, port=80, protocol="tcp")
+
+        # Generate a keypair for the instances
+        self.keypair = self.tester.add_keypair("keypair-" + self.test_hash)
         self.keypath = '%s/%s.pem' % (os.curdir, self.keypair.name)
 
-        ### Get an image
+        # User data file
+        self.user_data = "./testcases/cloud_user/elb/test_data/webserver_user_data.sh"
+
+        # Get an image
         self.image = self.args.emi
         if not self.image:
             self.image = self.tester.get_emi()
 
-        ### Populate available zones
+        # Populate available zones
         zones = self.tester.ec2.get_all_zones()
         self.zone = random.choice(zones).name
 
+        # create base load balancer
         self.load_balancer_port = 80
-
-        (self.web_servers, self.filename) = self.tester.create_web_servers(keypair=self.keypair,
-                                                                           group=self.group,
-                                                                           zone=self.zone,
-                                                                           port=self.load_balancer_port,
-                                                                           filename='instance-name',
-                                                                           image=self.image)
-
         self.load_balancer = self.tester.create_load_balancer(zones=[self.zone],
-                                                              name="test-" + str(int(time.time())),
+                                                              name="elb-" + self.test_hash,
                                                               load_balancer_port=self.load_balancer_port)
         assert isinstance(self.load_balancer, LoadBalancer)
-        self.tester.register_lb_instances(self.load_balancer.name,
-                                          self.web_servers.instances)
 
+        # create autoscaling group of webservers that register to the load balancer
+        self.count = 2
+        (self.web_servers) = self.tester.create_as_webservers(name=self.test_hash,
+                                                              keypair=self.keypair.name,
+                                                              group=self.group.name,
+                                                              zone=self.zone,
+                                                              image=self.image.id,
+                                                              count=self.count,
+                                                              user_data=self.user_data,
+                                                              load_balancer=self.load_balancer.name)
+
+        # web servers scaling group
+        self.asg = self.tester.describe_as_group(name="asg-"+self.test_hash)
+
+        # wait until scaling instances are InService with the load balancer before continuing - 5 min timeout
+        assert self.tester.wait_for_result(self.tester.wait_for_lb_instances, True, timeout=300,
+                                           lb=self.load_balancer.name, number=self.count)
 
     def clean_method(self):
         self.tester.cleanup_artifacts()
+        if self.tester.test_resources["security-groups"]:
+            for group in self.tester.test_resources["security-groups"]:
+                self.tester.wait_for_result(self.tester.gracefully_delete_group, True, timeout=60, group=group)
 
     def GenerateRequests(self):
         """
@@ -104,16 +121,12 @@ class StickinessBasics(EutesterTestCase):
         lb_url = "http://{0}:{1}/instance-name".format(lb_ip, self.load_balancer_port)
         return self.tester.generate_http_requests(url=lb_url, count=100, worker_threads=1)
 
-    def session_affinity_test(self):
+    def lb_cookie_session_affinity_test(self):
         lbpolicy = "LB-Policy"
         self.tester.create_lb_cookie_stickiness_policy(cookie_expiration_period=300,
                                                        lb_name=self.load_balancer.name,
                                                        policy_name=lbpolicy)
-        acpolicy = "AC-Policy"
-        self.tester.create_app_cookie_stickiness_policy(name="test-cookie",
-                                                        lb_name=self.load_balancer.name,
-                                                        policy_name=acpolicy)
-        """test lb stickiness"""
+        # test lb stickiness
         self.tester.sleep(2)
         self.debug("Testing LB cookie stickiness")
         self.tester.set_lb_policy(lb_name=self.load_balancer.name, lb_port=80, policy_name=lbpolicy)
@@ -124,8 +137,14 @@ class StickinessBasics(EutesterTestCase):
                 raise Exception(
                     "Expected same response due to load balancer stickiness policy. Got initial response: " + host +
                     " subsequent response: " + response)
+        return
 
-        """test app cookie stickiness"""
+    def app_cookie_session_affinity_test(self):
+        acpolicy = "AC-Policy"
+        self.tester.create_app_cookie_stickiness_policy(name="test-cookie",
+                                                        lb_name=self.load_balancer.name,
+                                                        policy_name=acpolicy)
+        # test app cookie stickiness
         self.tester.set_lb_policy(lb_name=self.load_balancer.name, lb_port=80, policy_name=acpolicy)
         self.debug("Testing App Cookie stickiness")
         responses = self.GenerateRequests()
@@ -139,12 +158,11 @@ class StickinessBasics(EutesterTestCase):
                     " subsequent response: " + response)
         return
 
-
 if __name__ == "__main__":
     testcase = StickinessBasics()
     ### Use the list of tests passed from config/command line to determine what subset of tests to run
     ### or use a predefined list
-    list = testcase.args.tests or ["session_affinity_test"]
+    list = testcase.args.tests or ["lb_cookie_session_affinity_test","app_cookie_session_affinity_test"]
 
     ### Convert test suite methods to EutesterUnitTest objects
     unit_list = []

--- a/testcases/cloud_user/elb/test_data/webserver_user_data.sh
+++ b/testcases/cloud_user/elb/test_data/webserver_user_data.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+if [ -e /etc/redhat-release ]; then
+  yum -y install httpd
+  chkconfig httpd on
+  echo "NameVirtualHost *:80" >> /etc/httpd/conf/httpd.conf
+  echo "CookieTracking on" >> /etc/httpd/conf/httpd.conf
+  echo "CookieName test-cookie" >> /etc/httpd/conf/httpd.conf
+  curl http://169.254.169.254/latest/meta-data/instance-id > /var/www/html/index.html
+  echo "" >> /var/www/html/index.html
+  service httpd start
+else
+  apt-get update
+  apt-get install -y apache2
+
+  # enable user tracking (for cookies and stickiness)
+  echo "CookieTracking on" >> /etc/apache2/apache2.conf
+  echo "CookieName test-cookie" >> /etc/apache2/apache2.conf
+  a2enmod usertrack
+
+  # write our own ssl key
+  echo '-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCoQdYwMwhOPldGxLljDIKpnAOrt3Q7uPt1hNC5yTnjjkZKdjP/
+50OMwuznStIFtGRnDSqNmNyd5cSj6WMvhIOeAaLM5K+tOMyX04nmoNI4zLZyYmtD
+AQbMznUiTZEvnOT/j5JKioi4d/+WTjE+ubNP1Gn79PyrsHRLEIMk6qc3BwIDAQAB
+AoGAaHno+6jUgXEoVGMXEi/UemjLxrZ1UBg+2+wKhzIx5eCUOOxIwZ/iS+dFnyDQ
+ZIZsyahdQesnIkxn27exxPGtn08g6Ow47+YPRACUpy/OMlRfqPENcVVu+Rn67U2O
+UEm/BwuCdAG6djnHVns3UHuZpIs/O9KqBJAvfmiO1sU2jOECQQDapFTYY8V3vASI
+2hf5rVyEjDYLOvSu5GsNa+Y6VZHNYXyfN9xOUE7frueF4p3yztDtUEPBOIVjAFNX
+dLBf4PZfAkEAxQGdMddY+7adoocx6Dhvz7hpzm+KBzIbCfJnQ90UF0JIbjlLHlkz
+YP8DZBUhq7cc0p5stm2hTM+b7Sl8J1hwWQJAcfaWAvR+SRrHgk2rkYi7YJt00AW6
+5C5LXoOPTXisttDJlHQZcPiLJCyWoUKt8ZG7dPcRWfWMET5qMnuwM0mfIQJBAKtK
+7voCKy2Zp9BESsGGKLnst5q14sbE6zun19/q3ugmSsID8OuvVXwV30XrFb6vVVFQ
+TGgGRIR70zDPrFKtk+kCQCJgjQhxxjM/SfRUJcA+x5ggy3X//7e975AXFcAiMcOr
+TFgtpamt/7y3wECO1prHZn4jZCrd1vM0Bmf+LyFikVE=
+-----END RSA PRIVATE KEY-----' > /etc/ssl/private/ssl-cert-snakeoil.key
+
+  # write our own ssl cert
+  echo '-----BEGIN CERTIFICATE-----
+MIICXjCCAccCAgPoMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIEwpDYWxpZm9ybmlhMRQwEgYDVQQHEwtHcmFuaXRlIEJheTETMBEGA1UEChMK
+RXVjYWx5cHR1czEQMA4GA1UECxMHUXVhbGl0eTEWMBQGA1UEAxMNQ2FzY2FkZS5s
+b2NhbDAeFw0xMzEyMTQwMDE1NDBaFw0yMzEyMTIwMDE1NDBaMHcxCzAJBgNVBAYT
+AlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRQwEgYDVQQHEwtHcmFuaXRlIEJheTET
+MBEGA1UEChMKRXVjYWx5cHR1czEQMA4GA1UECxMHUXVhbGl0eTEWMBQGA1UEAxMN
+Q2FzY2FkZS5sb2NhbDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAqEHWMDMI
+Tj5XRsS5YwyCqZwDq7d0O7j7dYTQuck5445GSnYz/+dDjMLs50rSBbRkZw0qjZjc
+neXEo+ljL4SDngGizOSvrTjMl9OJ5qDSOMy2cmJrQwEGzM51Ik2RL5zk/4+SSoqI
+uHf/lk4xPrmzT9Rp+/T8q7B0SxCDJOqnNwcCAwEAATANBgkqhkiG9w0BAQUFAAOB
+gQAyDQvZoPUfNGXur4hW6G8+rzchK/eX4Si6JBZWqBzi09r86vXwlr7ZEnbofnvA
+RjcgihEC1t3Z/Ew1VEMf49kZAXuTwbcevPVaWwHjuD4R6fQ3GBfr6hrh/Y/ZA215
+F3cpgmrg8e2tnHu6YAjkjQHbqSsUvxuG1R2fXj5uF+Q7ug==
+-----END CERTIFICATE-----' > /etc/ssl/certs/ssl-cert-snakeoil.pem
+
+  # enable ssl
+  ln -s  /etc/apache2/sites-available/default-ssl /etc/apache2/sites-enabled/000-ssl
+  a2enmod ssl
+
+  # create a target that returns the instance name
+  if [ -d /var/www/html ]; then
+    curl http://169.254.169.254/latest/meta-data/instance-id > /var/www/html/instance-name
+    echo "" >> /var/www/html/instance-name
+  else
+    curl http://169.254.169.254/latest/meta-data/instance-id > /var/www/instance-name
+    echo "" >> /var/www/instance-name
+  fi
+
+  # restart apache so our changes are applied
+  service apache2 restart
+fi


### PR DESCRIPTION
Several things done with this commit.
1. Setup webservers is now done with autoscaling groups + user data
2. Much better cleanup and tracking of test resources such as scaling groups, launch configs, and security groups
3. Scaling group and launch config cleanup added to default cleanup method
4. Server certificates work, including: fix list all certs and cleanup of certs
5. For stickiness test separated app-cookie-stickiness and lb-stickiness tests into their own test methods for better granularity of results