### PR TITLE
Use jcenter repo, update to 1.10.x for AWS SDK for Java.

### DIFF
--- a/eutester4j/build.xml
+++ b/eutester4j/build.xml
@@ -11,23 +11,19 @@
     <property name="eucarc" value="eucarc"/>
     <property name="endpoints" value="endpoints.xml"/>
     <property name="tests" value="AllTestsSuite.xml"/>
-
-    <!--youare sdk location link-->
-    <property name="YouAre" value="https://github.com/tbeckham/you-are-sdk/releases/download/alpha2/YouAreSDK.jar"/>
+    <property name="ivy.cache.ttl.default" value="1d"/>
 
     <!-- bootstrap-ivy -->
     <target name="bootstrap-ivy" description="Install ivy">
         <mkdir dir="${user.home}/.ant/lib"/>
         <get dest="${user.home}/.ant/lib/ivy.jar" src="http://search.maven.org/remotecontent?filepath=org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar"/>
+        <ivy:settings file="ivysettings.xml"/>
     </target>
 
     <!-- download testng and AWS JAVA SDK -->
     <target name="download-deps" depends="bootstrap-ivy">
         <mkdir dir="${deps.dir}"/>
         <ivy:retrieve conf="default" pattern="${deps.dir}/[artifact]-[revision].[ext]"/>
-        <echo message="fetching YouAre SDk..."/>
-        <get src="${YouAre}"
-             dest="${deps.dir}/YouAreSDK.jar"/>
         <gunzip src="zerofile.gz" dest="." />
     </target>
 

--- a/eutester4j/com/eucalyptus/tests/awssdk/EUCA8948.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/EUCA8948.java
@@ -133,9 +133,8 @@ public class EUCA8948 {
 			print("Expires = " + roleCreds.getExpiration());
 
 			print(account + ": Initializing s3 client with the temporary credentials");
-			final AmazonS3 s3 = new AmazonS3Client(new BasicSessionCredentials(roleCreds.getAccessKeyId(), roleCreds.getSecretAccessKey(),
-					roleCreds.getSessionToken()));
-			s3.setEndpoint(Eutester4j.S3_ENDPOINT);
+			final AmazonS3 s3 = Eutester4j.getS3Client(new BasicSessionCredentials( roleCreds.getAccessKeyId( ), roleCreds.getSecretAccessKey( ),
+					roleCreds.getSessionToken( ) ), Eutester4j.S3_ENDPOINT );
 			print("The owner of the account executing this call is " + s3.getS3AccountOwner());
 
 			print("Sleeping for " + (DURATION + 60) + " seconds to allow the credentials to expire");

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestCannedRoles.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestCannedRoles.java
@@ -202,7 +202,7 @@ public class TestCannedRoles {
                 @Override
                 public void run() {
                     print("Removing user key for account " + account);
-                    youAre.deleteAccessKey(new DeleteAccessKeyRequest(accessKey));
+                    youAre.deleteAccessKey(new DeleteAccessKeyRequest("admin", accessKey));
                 }
             });
 

--- a/eutester4j/ivy.xml
+++ b/eutester4j/ivy.xml
@@ -6,7 +6,17 @@
         <!-- core dependencies -->
         <dependency org="log4j" name="log4j" rev="1.2.17"/>
         <dependency org="org.testng" name="testng" rev="6.8.5"/>
-        <dependency org="com.amazonaws" name="aws-java-sdk" rev="1.8.9"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-autoscaling" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-cloudformation" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-cloudwatch" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-core" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-ec2" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-elasticloadbalancing" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-iam" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-simpleworkflow" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-sts" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-s3" rev="1.10.+"/>
+        <dependency org="com.github.sjones4" name="you-are-sdk" rev="1.0.+"/>
         <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
         <dependency org="org.codehaus.groovy" name="groovy-all" rev="1.8.9"/>
 

--- a/eutester4j/ivysettings.xml
+++ b/eutester4j/ivysettings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivysettings>
+  <settings defaultResolver="default"/>
+  <resolvers>
+    <ibiblio name="public"
+             m2compatible="true"
+             root="http://jcenter.bintray.com"/>
+  </resolvers>
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-main-chain.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-default-chain.xml"/>
+</ivysettings>


### PR DESCRIPTION
This pull request updates the build to use bintray jcenter for dependencies rather than maven central. Using bintray means the special handling for the YouAre SDK can be removed and a regular Ivy dependency used instead. The YouAre SDK is updated to the latest version, as is the AWS SDK for Java.