### PR TITLE
S3 iam condition key policy tests

### DIFF
--- a/eutester4j/build.xml
+++ b/eutester4j/build.xml
@@ -11,23 +11,19 @@
     <property name="eucarc" value="eucarc"/>
     <property name="endpoints" value="endpoints.xml"/>
     <property name="tests" value="AllTestsSuite.xml"/>
-
-    <!--youare sdk location link-->
-    <property name="YouAre" value="https://github.com/tbeckham/you-are-sdk/releases/download/alpha2/YouAreSDK.jar"/>
+    <property name="ivy.cache.ttl.default" value="1d"/>
 
     <!-- bootstrap-ivy -->
     <target name="bootstrap-ivy" description="Install ivy">
         <mkdir dir="${user.home}/.ant/lib"/>
         <get dest="${user.home}/.ant/lib/ivy.jar" src="http://search.maven.org/remotecontent?filepath=org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar"/>
+        <ivy:settings file="ivysettings.xml"/>
     </target>
 
     <!-- download testng and AWS JAVA SDK -->
     <target name="download-deps" depends="bootstrap-ivy">
         <mkdir dir="${deps.dir}"/>
         <ivy:retrieve conf="default" pattern="${deps.dir}/[artifact]-[revision].[ext]"/>
-        <echo message="fetching YouAre SDk..."/>
-        <get src="${YouAre}"
-             dest="${deps.dir}/YouAreSDK.jar"/>
         <gunzip src="zerofile.gz" dest="." />
     </target>
 

--- a/eutester4j/com/eucalyptus/tests/awssdk/EUCA8948.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/EUCA8948.java
@@ -133,9 +133,8 @@ public class EUCA8948 {
 			print("Expires = " + roleCreds.getExpiration());
 
 			print(account + ": Initializing s3 client with the temporary credentials");
-			final AmazonS3 s3 = new AmazonS3Client(new BasicSessionCredentials(roleCreds.getAccessKeyId(), roleCreds.getSecretAccessKey(),
-					roleCreds.getSessionToken()));
-			s3.setEndpoint(Eutester4j.S3_ENDPOINT);
+			final AmazonS3 s3 = Eutester4j.getS3Client(new BasicSessionCredentials( roleCreds.getAccessKeyId( ), roleCreds.getSecretAccessKey( ),
+					roleCreds.getSessionToken( ) ), Eutester4j.S3_ENDPOINT );
 			print("The owner of the account executing this call is " + s3.getS3AccountOwner());
 
 			print("Sleeping for " + (DURATION + 60) + " seconds to allow the credentials to expire");

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestCannedRoles.java
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestCannedRoles.java
@@ -202,7 +202,7 @@ public class TestCannedRoles {
                 @Override
                 public void run() {
                     print("Removing user key for account " + account);
-                    youAre.deleteAccessKey(new DeleteAccessKeyRequest(accessKey));
+                    youAre.deleteAccessKey(new DeleteAccessKeyRequest("admin", accessKey));
                 }
             });
 

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyLocationConstraint.groovy
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyLocationConstraint.groovy
@@ -1,0 +1,251 @@
+package com.eucalyptus.tests.awssdk
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.handlers.AbstractRequestHandler
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.identitymanagement.model.*
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import com.amazonaws.services.s3.model.CreateBucketRequest
+import com.github.sjones4.youcan.youare.YouAre
+import com.github.sjones4.youcan.youare.YouAreClient
+import com.github.sjones4.youcan.youare.model.CreateAccountRequest
+import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
+import org.testng.Assert
+import org.testng.annotations.Test
+
+import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
+import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
+import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
+import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+
+/**
+ * Tests IAM locationConstraint condition key for S3.
+ *
+ * Related issues:
+ *   https://eucalyptus.atlassian.net/browse/EUCA-11010
+ *
+ * Related AWS doc:
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
+ */
+class TestS3IAMConditionKeyLocationConstraint {
+
+  private final String host
+  private final AWSCredentialsProvider credentials
+
+  TestS3IAMConditionKeyLocationConstraint( ) {
+    minimalInit()
+    this.host = HOST_IP
+    this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
+  }
+
+  private String cloudUri( String host, String servicePath ) {
+    URI.create( "http://${host}:8773/" )
+        .resolve( servicePath )
+        .toString( )
+  }
+
+  private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
+    final YouAreClient euare = new YouAreClient( credentials )
+    if ( host ) {
+      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    } else {
+      euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
+    }
+    euare
+  }
+
+  private AmazonS3 getS3Client( final AWSCredentialsProvider credentials ) {
+    final ClientConfiguration clientConfiguration = new ClientConfiguration( )
+    clientConfiguration.signerOverride = 'S3SignerType'
+    final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
+    if ( host ) {
+      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+      s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
+    }
+    return s3;
+  }
+
+  private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
+    final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
+    if ( host ) {
+      ec2.setEndpoint( cloudUri( host, '/services/compute' ) )
+    }
+    return ec2;
+  }
+
+  private boolean assertTrue( boolean condition,
+                              String message ){
+    Assert.assertTrue( condition, message )
+    true
+  }
+
+  private void print( String text ) {
+    System.out.println( text )
+  }
+
+  @Test
+  void testS3IAMConditionKeyLocationConstraintTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final Collection<String> regions = getEC2Client( credentials ).with {
+      describeRegions( ).with {
+        regions*.regionName
+      }
+    }
+    assertTrue( !regions.isEmpty( ), 'No regions found' )
+    print( "Detected regions: ${regions}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      getS3Client( adminCredentials ).with {
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+      }
+
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add{
+          println( "Deleting user ${userName}" )
+          deleteUser( new DeleteUserRequest(
+              userName: userName
+          ) )
+        }
+        print( "Creating user ${userName}" )
+        createUser( new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ) )
+
+        String policyName = "${namePrefix}policy1"
+        print( "Creating user policy ${policyName}" )
+        putUserPolicy( new PutUserPolicyRequest(
+            userName: userName,
+            policyName: policyName,
+            policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:CreateBucket"
+                    ],
+                    "Resource": "*",
+                    "Condition": {"StringLike": {"s3:LocationConstraint": [ "${regions.join('","')}" ]}}
+                  }
+                ]
+              }
+              """.stripIndent( )
+        ) )
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      getS3Client( userCredentials ).with {
+        String region = regions.iterator( ).next( )
+        print( "Creating bucket in permitted region ${region}" )
+        createBucket( new CreateBucketRequest( bucketName, region ) )
+
+        print( "Creating bucket in non-permitted region invalid-region (should fail)" )
+        try {
+          createBucket( bucketName + "-invalid", 'invalid-region' )
+          assertTrue( false, 'Expected bucket creation to fail for non-permitted region' )
+        } catch (AmazonServiceException e) {
+          print( "Expected bucket creation failure: ${e}" )
+        }
+
+        void
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup" )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+}

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyVersionId.groovy
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyVersionId.groovy
@@ -1,0 +1,322 @@
+package com.eucalyptus.tests.awssdk
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.handlers.AbstractRequestHandler
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.identitymanagement.model.*
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import com.amazonaws.services.s3.model.BucketVersioningConfiguration
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.S3VersionSummary
+import com.amazonaws.services.s3.model.SetBucketVersioningConfigurationRequest
+import com.github.sjones4.youcan.youare.YouAre
+import com.github.sjones4.youcan.youare.YouAreClient
+import com.github.sjones4.youcan.youare.model.CreateAccountRequest
+import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
+import org.testng.Assert
+import org.testng.annotations.Test
+
+import java.nio.charset.StandardCharsets
+
+import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit;
+import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP;
+import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY;
+import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
+
+/**
+ * Tests IAM versionId condition key for S3.
+ *
+ * Related issues:
+ *   https://eucalyptus.atlassian.net/browse/EUCA-11010
+ *
+ * Related AWS doc:
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
+ */
+class TestS3IAMConditionKeyVersionId {
+
+  private final String host
+  private final AWSCredentialsProvider credentials
+
+  TestS3IAMConditionKeyVersionId( ) {
+    minimalInit()
+    this.host = HOST_IP
+    this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
+  }
+
+  private String cloudUri( String host, String servicePath ) {
+    URI.create( "http://${host}:8773/" )
+        .resolve( servicePath )
+        .toString( )
+  }
+
+  private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
+    final YouAreClient euare = new YouAreClient( credentials )
+    if ( host ) {
+      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    } else {
+      euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
+    }
+    euare
+  }
+
+  private AmazonS3 getS3Client( final AWSCredentialsProvider credentials ) {
+    final ClientConfiguration clientConfiguration = new ClientConfiguration( )
+    clientConfiguration.signerOverride = 'S3SignerType'
+    final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
+    if ( host ) {
+      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+      s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
+    }
+    return s3;
+  }
+
+  private boolean assertTrue( boolean condition,
+                              String message ){
+    Assert.assertTrue( condition, message )
+    true
+  }
+
+  private void print( String text ) {
+    System.out.println( text )
+  }
+
+  @Test
+  void testS3IAMConditionKeyVersionIdTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      String version1 = null
+      String version2 = null
+      String version3 = null
+      getS3Client( adminCredentials ).with {
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+
+        print( "Creating bucket ${bucketName}" )
+        createBucket( bucketName )
+
+        print( "Enabling versioning for bucket: ${bucketName}" )
+        setBucketVersioningConfiguration( new SetBucketVersioningConfigurationRequest(
+            bucketName,
+            new BucketVersioningConfiguration( BucketVersioningConfiguration.ENABLED )
+        ) )
+
+        print( "Putting foo object version to ${bucketName}" )
+        putObject( bucketName, 'foo', new ByteArrayInputStream( "Data version 1".getBytes( StandardCharsets.UTF_8 ) ), new ObjectMetadata( ) );
+
+        print( "Putting foo object version to ${bucketName}" )
+        putObject( bucketName, 'foo', new ByteArrayInputStream( "Data version 2".getBytes( StandardCharsets.UTF_8 ) ), new ObjectMetadata( ) );
+
+        print( "Deleting foo object from ${bucketName}" )  // create delete marker as v3
+        deleteObject( bucketName, 'foo' );
+
+        print( "Listing foo object versions" )
+        listVersions( bucketName, 'foo' ).with {
+          versionSummaries.each { S3VersionSummary versionSummary ->
+            print( "${versionSummary.bucketName}/${versionSummary.key} ${versionSummary.versionId}" )
+            cleanupTasks.add {
+              print( "Deleting object foo with version ${versionSummary.versionId} from bucket ${bucketName}" )
+              deleteVersion( bucketName, 'foo', versionSummary.versionId )
+            }
+          }
+          assertTrue( versionSummaries.size() == 3, "Expected 3 versions but was ${versionSummaries.size()}" )
+          version1 = versionSummaries[0].versionId
+          version2 = versionSummaries[1].versionId
+          version3 = versionSummaries[2].versionId
+        }
+      }
+      assertTrue( version1 != null, "Expected version 1" )
+      assertTrue( version2 != null, "Expected version 2" )
+      assertTrue( version3 != null, "Expected version 3" )
+
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add{
+          println( "Deleting user ${userName}" )
+          deleteUser( new DeleteUserRequest(
+              userName: userName
+          ) )
+        }
+        print( "Creating user ${userName}" )
+        createUser( new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ) )
+
+        String policyName = "${namePrefix}policy1"
+        print( "Creating user policy ${policyName}" )
+        putUserPolicy( new PutUserPolicyRequest(
+            userName: userName,
+            policyName: policyName,
+            policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:GetObjectVersion",
+                      "s3:GetObjectVersionAcl",
+                      "s3:PutObjectVersionAcl",
+                      "s3:DeleteObjectVersion"
+                    ],
+                    "Resource": "arn:aws:s3:::${bucketName}/foo",
+                    "Condition": {"StringLike": {"s3:VersionId": [ "${version2}" ]}}
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:DeleteObjectVersion"
+                    ],
+                    "Resource": "arn:aws:s3:::${bucketName}/foo",
+                    "Condition": {"StringEquals": {"s3:VersionId": [ "${version3}" ]}}
+                  }
+                ]
+              }
+              """.stripIndent( )
+        ) )
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      getS3Client( userCredentials ).with {
+        print( "******************************************************" )
+        print( "TODO: Enable tests for GetObjectVersion when supported" )
+        print( "******************************************************" )
+//        print( "Getting object foo version ${version2} from ${bucketName}" )
+//        getObject( new GetObjectRequest( bucketName, 'foo', version2 ) ).with {
+//          print( "Got object ${key}" )
+//        }
+//
+//        try {
+//          print( "Getting object foo version ${version1} from ${bucketName}, should fail" )
+//          getObject( new GetObjectRequest( bucketName, 'foo', version1 ) ).with {
+//            print( "Got object ${key}" )
+//            assertTrue( false, "Expected get object version to fail for user due to permissions" )
+//          }
+//        } catch ( AmazonServiceException e ) {
+//          print( "Expected error getting object version without permission: ${e}" )
+//        }
+//
+//        try {
+//          print( "Getting object foo ${version1} from ${bucketName}, should fail" )
+//          getObject( new GetObjectRequest( bucketName, 'foo' ) ).with {
+//            print( "Got object ${key}" )
+//            assertTrue( false, "Expected get object to fail for user due to permissions" )
+//          }
+//        } catch ( AmazonServiceException e ) {
+//          print( "Expected error getting object without permission: ${e}" )
+//        }
+
+        print( "**************************************************************************" )
+        print( "TODO: Add tests for PutObjectVersionAcl/GetObjectVersionAcl when supported" )
+        print( "**************************************************************************" )
+
+        print( "Deleting object foo version ${version3} from ${bucketName}" )
+        deleteVersion( bucketName, 'foo', version3 );
+
+        print( "Deleting object foo version ${version2} from ${bucketName}" )
+        deleteVersion( bucketName, 'foo', version2 );
+
+        try {
+          print( "Deleting object foo version ${version1} from ${bucketName}, should fail" )
+          deleteVersion( bucketName, 'foo', version1  );
+          assertTrue( false, "Expected delete object version to fail for user due to permissions" )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error deleting object version without permission: ${e}" )
+        }
+
+        void
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup" )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+}

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForAclsAndGrants.groovy
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForAclsAndGrants.groovy
@@ -1,0 +1,591 @@
+package com.eucalyptus.tests.awssdk
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.handlers.AbstractRequestHandler
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.identitymanagement.model.*
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import com.amazonaws.services.s3.model.AccessControlList
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.CanonicalGrantee
+import com.amazonaws.services.s3.model.CreateBucketRequest
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.Owner
+import com.amazonaws.services.s3.model.Permission
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.github.sjones4.youcan.youare.YouAre
+import com.github.sjones4.youcan.youare.YouAreClient
+import com.github.sjones4.youcan.youare.model.CreateAccountRequest
+import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
+import org.testng.Assert
+import org.testng.annotations.Test
+
+import java.nio.charset.StandardCharsets
+
+import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
+import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
+import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+
+/**
+ * Tests IAM x-amz-acl and x-amz-grant-* condition keys for S3.
+ *
+ * Related issues:
+ *   https://eucalyptus.atlassian.net/browse/EUCA-11010
+ *
+ * Related AWS doc:
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
+ */
+class TestS3IAMConditionKeysForAclsAndGrants {
+
+  private final String host
+  private final AWSCredentialsProvider credentials
+
+  TestS3IAMConditionKeysForAclsAndGrants( ) {
+    minimalInit()
+    this.host = HOST_IP
+    this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
+  }
+
+  private String cloudUri( String host, String servicePath ) {
+    URI.create( "http://${host}:8773/" )
+        .resolve( servicePath )
+        .toString( )
+  }
+
+  private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
+    final YouAreClient euare = new YouAreClient( credentials )
+    if ( host ) {
+      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    } else {
+      euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
+    }
+    euare
+  }
+
+  private AmazonS3 getS3Client( final AWSCredentialsProvider credentials ) {
+    final ClientConfiguration clientConfiguration = new ClientConfiguration( )
+    clientConfiguration.signerOverride = 'S3SignerType'
+    final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
+    if ( host ) {
+      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+      s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
+    }
+    return s3;
+  }
+
+  private boolean assertTrue( boolean condition,
+                              String message ){
+    Assert.assertTrue( condition, message )
+    true
+  }
+
+  private void print( String text ) {
+    System.out.println( text )
+  }
+
+  @Test
+  void testS3IAMConditionKeysForAclsTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      getS3Client( adminCredentials ).with {
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+
+        cleanupTasks.add {
+          [ 'foo' ].each { String key ->
+            print("Deleting ${key} object from ${bucketName}")
+            deleteObject( bucketName, key );
+          }
+        }
+      }
+
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add{
+          println( "Deleting user ${userName}" )
+          deleteUser( new DeleteUserRequest(
+              userName: userName
+          ) )
+        }
+        print( "Creating user ${userName}" )
+        createUser( new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ) )
+
+        String policyName = "${namePrefix}policy1"
+        print( "Creating user policy ${policyName}" )
+        putUserPolicy( new PutUserPolicyRequest(
+            userName: userName,
+            policyName: policyName,
+            policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:CreateBucket"
+                    ],
+                    "Resource": "*",
+                    "Condition": {
+                      "StringEquals": {
+                        "s3:x-amz-acl": "public-read"
+                      }
+                    }
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:PutBucketAcl",
+                      "s3:PutObject",
+                      "s3:PutObjectAcl"
+                    ],
+                    "Resource": [
+                      "arn:aws:s3:::${bucketName}",
+                      "arn:aws:s3:::${bucketName}/*"
+                    ],
+                    "Condition": {
+                      "StringEquals": {
+                        "s3:x-amz-acl": "public-read"
+                      }
+                    }
+                  }
+                ]
+              }
+              """.stripIndent( )
+        ) )
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      getS3Client( userCredentials ).with {
+        print( "Creating bucket ${bucketName} with public-read predefined ACL" )
+        createBucket( new CreateBucketRequest( bucketName )
+            .withCannedAcl( CannedAccessControlList.PublicRead ) )
+
+        print( "Creating bucket ${bucketName}-2 with bucket-owner-full-control predefined ACL (should fail)" )
+        try {
+          createBucket( new CreateBucketRequest( "${bucketName}-2" )
+              .withCannedAcl( CannedAccessControlList.BucketOwnerFullControl ) )
+          assertTrue( false, 'Expected failure due to incorrect canned ACL' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for create bucket failure: ${e}" )
+        }
+
+        print( "Putting bucket ${bucketName} ACL with public-read predefined ACL" )
+        setBucketAcl( bucketName, CannedAccessControlList.PublicRead )
+
+        print( "Putting bucket ${bucketName} ACL with bucket-owner-full-control predefined ACL  (should fail)" )
+        try {
+          setBucketAcl( bucketName, CannedAccessControlList.BucketOwnerFullControl )
+          assertTrue( false, 'Expected failure due to incorrect canned ACL' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for put bucket ACL failure: ${e}" )
+        }
+
+        print( "Putting object ${bucketName}/foo with public-read predefined ACL" )
+        putObject( new PutObjectRequest(
+            bucketName,
+            'foo',
+            new ByteArrayInputStream( "foo data".getBytes( StandardCharsets.UTF_8 ) ),
+            new ObjectMetadata( ) ).withCannedAcl( CannedAccessControlList.PublicRead )
+        );
+
+        print( "Putting object bar with bucket-owner-full-control predefined ACL (should fail)" )
+        try {
+          putObject( new PutObjectRequest(
+              bucketName,
+              'bar',
+              new ByteArrayInputStream( "foo data".getBytes( StandardCharsets.UTF_8 ) ),
+              new ObjectMetadata( ) ).withCannedAcl( CannedAccessControlList.BucketOwnerFullControl )
+          );
+          assertTrue( false, 'Expected failure due to incorrect canned ACL' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for put failure: ${e}" )
+        }
+
+        print( "Putting object ${bucketName}/foo ACL with public-read predefined ACL" )
+        setObjectAcl( bucketName, 'foo', CannedAccessControlList.PublicRead )
+
+        print( "Putting object ${bucketName}/foo ACL with bucket-owner-full-control predefined ACL (should fail)" )
+        try {
+          setObjectAcl( bucketName, 'foo', CannedAccessControlList.BucketOwnerFullControl )
+          assertTrue( false, 'Expected failure due to incorrect canned ACL' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for put object ACL failure: ${e}" )
+        }
+
+        void
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup" )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+
+  @Test
+  void testS3IAMConditionKeysForGrantsTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      String granteeAccountCanonicalId = null
+      getS3Client( credentials ).with {
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}-admin" )
+          deleteBucket( "${bucketName}-admin" )
+        }
+
+        createBucket( "${bucketName}-admin" )
+
+        granteeAccountCanonicalId = getBucketAcl( "${bucketName}-admin" ).with { AccessControlList acl ->
+          acl?.owner?.id
+        }
+
+        deleteBucket( "${bucketName}-admin" )
+      }
+      assertTrue( granteeAccountCanonicalId != null, "Expected granteeAccountCanonicalId but was null" )
+
+      String adminAccountCanonicalId = null
+      getS3Client( adminCredentials ).with {
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+
+        cleanupTasks.add {
+          [ 'foo' ].each { String key ->
+            print("Deleting ${key} object from ${bucketName}")
+            deleteObject( bucketName, key );
+          }
+        }
+
+        createBucket( bucketName )
+
+        adminAccountCanonicalId = getBucketAcl( bucketName ).with { AccessControlList acl ->
+          acl?.owner?.id
+        }
+
+        deleteBucket( bucketName )
+
+        void
+      }
+      assertTrue( adminAccountCanonicalId != null, "Expected adminAccountCanonicalId but was null" )
+
+      String policyName = "${namePrefix}policy1"
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add {
+          println("Deleting user ${userName}")
+          deleteUser(new DeleteUserRequest(
+              userName: userName
+          ))
+        }
+        print("Creating user ${userName}")
+        createUser(new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ))
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      [ 'read', 'write', 'read-acp', 'write-acp', 'full-control' ].each { String permission ->
+        String invalidPermission = permission == 'read' ? 'write' : 'read'
+        getYouAreClient( adminCredentials ).with {
+          print( "Setting user policy ${policyName}" )
+          putUserPolicy( new PutUserPolicyRequest(
+              userName: userName,
+              policyName: policyName,
+              policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:CreateBucket"
+                    ],
+                    "Resource": "*",
+                    "Condition": {
+                      "StringEquals": {
+                        "s3:x-amz-grant-${permission}": "id=${granteeAccountCanonicalId}"
+                      }
+                    }
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:PutBucketAcl",
+                      "s3:PutObject",
+                      "s3:PutObjectAcl"
+                    ],
+                    "Resource": [
+                      "arn:aws:s3:::${bucketName}",
+                      "arn:aws:s3:::${bucketName}/*"
+                    ],
+                    "Condition": {
+                      "StringEquals": {
+                        "s3:x-amz-grant-${permission}": "id=${granteeAccountCanonicalId}"
+                      }
+                    }
+                  }
+                ]
+              }
+              """.stripIndent( )
+          ) )
+        }
+
+        println( "Sleeping to ensure policy applied" )
+        sleep( 5000 )
+
+        getS3Client( userCredentials ).with {
+          print( "Creating bucket ${bucketName} with x-amz-grant-${permission} for ${granteeAccountCanonicalId} ACL" )
+          createBucket( new CreateBucketRequest( bucketName )
+              .withAccessControlList( acl( adminAccountCanonicalId, granteeAccountCanonicalId, permission ) ) )
+
+          print( "Creating bucket ${bucketName}-2 with x-amz-grant-${invalidPermission} for ${granteeAccountCanonicalId} ACL (should fail)" )
+          try {
+            createBucket( new CreateBucketRequest( bucketName )
+                .withAccessControlList( acl( adminAccountCanonicalId, granteeAccountCanonicalId, invalidPermission ) ) )
+            assertTrue( false, 'Expected failure due to incorrect ACL permission' )
+          } catch ( AmazonServiceException e ) {
+            print( "Expected error for create bucket failure: ${e}" )
+          }
+
+          print( "Putting bucket ${bucketName} ACL with x-amz-grant-${permission} for ${granteeAccountCanonicalId} ACL" )
+          setBucketAcl( bucketName, acl( adminAccountCanonicalId, granteeAccountCanonicalId, permission ) )
+
+          print( "Putting bucket ${bucketName} ACL with x-amz-grant-${invalidPermission} for ${granteeAccountCanonicalId} ACL (should fail)" )
+          try {
+            setBucketAcl( bucketName, acl( adminAccountCanonicalId, granteeAccountCanonicalId, invalidPermission ) )
+            assertTrue( false, 'Expected failure due to incorrect ACL permission' )
+          } catch ( AmazonServiceException e ) {
+            print( "Expected error for put bucket ACL failure: ${e}" )
+          }
+
+          print( "Putting object ${bucketName}/foo with x-amz-grant-${permission} for ${granteeAccountCanonicalId} ACL" )
+          putObject( new PutObjectRequest(
+              bucketName,
+              'foo',
+              new ByteArrayInputStream( "foo data".getBytes( StandardCharsets.UTF_8 ) ),
+              new ObjectMetadata( ) ).withAccessControlList( acl( adminAccountCanonicalId, granteeAccountCanonicalId, permission ) )
+          );
+
+          print( "Putting object ${bucketName}/bar with with x-amz-grant-${invalidPermission} for ${granteeAccountCanonicalId} ACL (should fail)" )
+          try {
+            putObject( new PutObjectRequest(
+                bucketName,
+                'bar',
+                new ByteArrayInputStream( "foo data".getBytes( StandardCharsets.UTF_8 ) ),
+                new ObjectMetadata( ) ).withAccessControlList( acl( adminAccountCanonicalId, granteeAccountCanonicalId, invalidPermission ) )
+            );
+            assertTrue( false, 'Expected failure due to incorrect ACL permission' )
+          } catch ( AmazonServiceException e ) {
+            print( "Expected error for put failure: ${e}" )
+          }
+
+          print( "Putting object ${bucketName}/foo ACL with x-amz-grant-${permission} for ${granteeAccountCanonicalId} ACL" )
+          setObjectAcl( bucketName, 'foo', acl( adminAccountCanonicalId, granteeAccountCanonicalId, permission ) )
+
+          print( "Putting object ${bucketName}/foo ACL with x-amz-grant-${invalidPermission} for ${granteeAccountCanonicalId} ACL (should fail)" )
+          try {
+            setObjectAcl( bucketName, 'foo', acl( adminAccountCanonicalId, granteeAccountCanonicalId, invalidPermission ) )
+            assertTrue( false, 'Expected failure due to incorrect ACL permission' )
+          } catch ( AmazonServiceException e ) {
+            print( "Expected error for put object ACL failure: ${e}" )
+          }
+
+          void
+        }
+
+        getS3Client( adminCredentials ).with {
+          [ 'foo' ].each { String key ->
+            print("Deleting ${key} object from ${bucketName}")
+            deleteObject( bucketName, key );
+          }
+
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup" )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+
+  private static AccessControlList acl( String ownerId, String granteeId, String permission ) {
+    new AccessControlList( ).with{ AccessControlList acl ->
+      setOwner( new Owner( id: ownerId ) )
+      grantPermission(
+          new CanonicalGrantee( granteeId ),
+          Permission.values( ).find{ Permission perm -> perm.headerName == ("x-amz-grant-${permission}" as String) } )
+      acl
+    }
+  }
+}

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForPutObject.groovy
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForPutObject.groovy
@@ -1,0 +1,285 @@
+package com.eucalyptus.tests.awssdk
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.handlers.AbstractRequestHandler
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.identitymanagement.model.*
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import com.amazonaws.services.s3.model.*
+import com.github.sjones4.youcan.youare.YouAre
+import com.github.sjones4.youcan.youare.YouAreClient
+import com.github.sjones4.youcan.youare.model.CreateAccountRequest
+import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
+import org.testng.Assert
+import org.testng.annotations.Test
+
+import java.nio.charset.StandardCharsets
+
+import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
+import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
+import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+
+/**
+ * Tests IAM x-amz-copy-source and x-amz-metadata-directive condition keys for S3.
+ *
+ * Related issues:
+ *   https://eucalyptus.atlassian.net/browse/EUCA-11010
+ *
+ * Related AWS doc:
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
+ */
+class TestS3IAMConditionKeysForPutObject {
+
+  private final String host
+  private final AWSCredentialsProvider credentials
+
+  TestS3IAMConditionKeysForPutObject( ) {
+    minimalInit()
+    this.host = HOST_IP
+    this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
+  }
+
+  private String cloudUri( String host, String servicePath ) {
+    URI.create( "http://${host}:8773/" )
+        .resolve( servicePath )
+        .toString( )
+  }
+
+  private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
+    final YouAreClient euare = new YouAreClient( credentials )
+    if ( host ) {
+      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    } else {
+      euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
+    }
+    euare
+  }
+
+  private AmazonS3 getS3Client( final AWSCredentialsProvider credentials ) {
+    final ClientConfiguration clientConfiguration = new ClientConfiguration( )
+    clientConfiguration.signerOverride = 'S3SignerType'
+    final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
+    if ( host ) {
+      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+      s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
+    }
+    return s3;
+  }
+
+  private boolean assertTrue( boolean condition,
+                              String message ){
+    Assert.assertTrue( condition, message )
+    true
+  }
+
+  private void print( String text ) {
+    System.out.println( text )
+  }
+
+  @Test
+  void testS3IAMConditionKeysForPutObjectTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      getS3Client( adminCredentials ).with {
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+
+        print( "Creating bucket ${bucketName}" )
+        createBucket( bucketName )
+
+        cleanupTasks.add {
+          [ 'foo', 'foo-2', 'foo-copy-1' ].each { String key ->
+            print("Deleting ${key} object from ${bucketName}")
+            deleteObject( bucketName, key );
+          }
+        }
+
+        [ 'foo', 'foo-2' ].each{ String key ->
+          print( "Putting ${key} object to ${bucketName}" )
+          putObject( bucketName, key, new ByteArrayInputStream( "${key} data".getBytes( StandardCharsets.UTF_8 ) ), new ObjectMetadata( ) );
+        }
+      }
+
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add{
+          println( "Deleting user ${userName}" )
+          deleteUser( new DeleteUserRequest(
+              userName: userName
+          ) )
+        }
+        print( "Creating user ${userName}" )
+        createUser( new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ) )
+
+        String policyName = "${namePrefix}policy1"
+        print( "Creating user policy ${policyName}" )
+        putUserPolicy( new PutUserPolicyRequest(
+            userName: userName,
+            policyName: policyName,
+            policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:GetObject"
+                  ],
+                    "Resource": "arn:aws:s3:::${bucketName}/foo"
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:PutObject"
+                    ],
+                    "Resource": "arn:aws:s3:::${bucketName}/*",
+                    "Condition": {
+                      "StringEquals": {
+                        "s3:x-amz-metadata-directive": "REPLACE",
+                        "s3:x-amz-copy-source": "/${bucketName}/foo"
+                      }
+                    }
+                  }
+                ]
+              }
+              """.stripIndent( )
+        ) )
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      getS3Client( userCredentials ).with {
+        print( "Copying object foo with replacement metadata" )
+        copyObject( new CopyObjectRequest( bucketName, 'foo', bucketName, 'foo-copy-1' )
+            .withNewObjectMetadata( new ObjectMetadata(
+              lastModified: new Date( )
+            ) )
+        )
+
+        print( "Copying object foo without replacing metadata (should fail)" )
+        try {
+          copyObject( new CopyObjectRequest( bucketName, 'foo', bucketName, 'foo-copy-2' ) )
+          assertTrue( false, 'Expected failure due to metadata not replaced' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for copy failure: ${e}" )
+        }
+
+        print( "Copying object foo-2 (should fail)" )
+        try {
+          copyObject( new CopyObjectRequest( bucketName, 'foo-2', bucketName, 'foo-2-copy-1' )
+              .withNewObjectMetadata( new ObjectMetadata(
+              lastModified: new Date( )
+          ) )
+          )
+          assertTrue( false, 'Expected failure due to copy source not permitted' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for copy failure: ${e}" )
+        }
+
+        print( "Putting object bar (should fail)" )
+        try {
+          putObject( bucketName, 'bar', new ByteArrayInputStream( "bar data".getBytes( StandardCharsets.UTF_8 ) ), new ObjectMetadata( ) );
+          assertTrue( false, 'Expected failure due to no copy source' )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error for copy failure: ${e}" )
+        }
+
+        void
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup" )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+}

--- a/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysPrefixAndDelimiter.groovy
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysPrefixAndDelimiter.groovy
@@ -1,0 +1,521 @@
+package com.eucalyptus.tests.awssdk
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.handlers.AbstractRequestHandler
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.identitymanagement.model.*
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import com.amazonaws.services.s3.model.BucketVersioningConfiguration
+import com.amazonaws.services.s3.model.ListObjectsRequest
+import com.amazonaws.services.s3.model.ListVersionsRequest
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.amazonaws.services.s3.model.S3VersionSummary
+import com.amazonaws.services.s3.model.SetBucketVersioningConfigurationRequest
+import com.github.sjones4.youcan.youare.YouAre
+import com.github.sjones4.youcan.youare.YouAreClient
+import com.github.sjones4.youcan.youare.model.CreateAccountRequest
+import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
+import org.testng.Assert
+import org.testng.annotations.Test
+
+import java.nio.charset.StandardCharsets
+
+import static com.eucalyptus.tests.awssdk.Eutester4j.minimalInit
+import static com.eucalyptus.tests.awssdk.Eutester4j.HOST_IP
+import static com.eucalyptus.tests.awssdk.Eutester4j.ACCESS_KEY
+import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY
+
+/**
+ * Tests IAM prefix and delimiter condition keys for S3.
+ *
+ * Related issues:
+ *   https://eucalyptus.atlassian.net/browse/EUCA-8582
+ *   https://eucalyptus.atlassian.net/browse/EUCA-11010
+ *
+ * Related AWS doc:
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html
+ *   http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html
+ *   http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_examples.html#iam-policy-example-s3-home-directory
+ */
+class TestS3IAMConditionKeysPrefixAndDelimiter {
+
+  private final String host
+  private final AWSCredentialsProvider credentials
+
+  TestS3IAMConditionKeysPrefixAndDelimiter( ) {
+    minimalInit()
+    this.host = HOST_IP
+    this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
+  }
+
+  private String cloudUri( String host, String servicePath ) {
+    URI.create( "http://${host}:8773/" )
+        .resolve( servicePath )
+        .toString( )
+  }
+
+  private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
+    final YouAreClient euare = new YouAreClient( credentials )
+    if ( host ) {
+      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    } else {
+      euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
+    }
+    euare
+  }
+
+  private AmazonS3 getS3Client( final AWSCredentialsProvider credentials ) {
+    final ClientConfiguration clientConfiguration = new ClientConfiguration( )
+    clientConfiguration.signerOverride = 'S3SignerType'
+    final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
+    if ( host ) {
+      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+      s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
+    }
+    return s3;
+  }
+
+  private boolean assertTrue( boolean condition,
+                              String message ){
+    Assert.assertTrue( condition, message )
+    true
+  }
+
+  private void print( String text ) {
+    System.out.println( text )
+  }
+
+  @Test
+  void testS3IAMConditionKeysPrefixAndDelimiterTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      getS3Client( adminCredentials ).with {
+        cleanupTasks.add{
+          print( "Deleting object versions from bucket ${bucketName}" )
+          listVersions( bucketName, null ).with {
+            versionSummaries.each { S3VersionSummary version ->
+              deleteVersion( bucketName, version.key, version.versionId )
+            }
+          }
+
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+
+        print( "Creating bucket ${bucketName}" )
+        createBucket( bucketName )
+
+        cleanupTasks.add {
+          ['foo', 'bar', 'dir/foo', 'dir/bar', 'comma,foo', 'comma,bar'].each { String key ->
+            print("Deleting ${key} object from ${bucketName}")
+            deleteObject( bucketName, key );
+          }
+        }
+
+        [ 'foo', 'bar', 'dir/foo', 'dir/bar', 'comma,foo', 'comma,bar' ].each{ String key ->
+          print( "Putting ${key} object to ${bucketName}" )
+          putObject( bucketName, key, new ByteArrayInputStream( "${key} data".getBytes( StandardCharsets.UTF_8 ) ), new ObjectMetadata( ) );
+        }
+
+        cleanupTasks.add{
+          print( "Disabling versioning for bucket: ${bucketName}"  )
+          setBucketVersioningConfiguration( new SetBucketVersioningConfigurationRequest(
+              bucketName,
+              new BucketVersioningConfiguration( BucketVersioningConfiguration.SUSPENDED )
+          ) )
+        }
+
+        print( "Enabling versioning for bucket: ${bucketName}"  )
+        setBucketVersioningConfiguration( new SetBucketVersioningConfigurationRequest(
+            bucketName,
+            new BucketVersioningConfiguration( BucketVersioningConfiguration.ENABLED )
+        ) )
+      }
+
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add{
+          println( "Deleting user ${userName}" )
+          deleteUser( new DeleteUserRequest(
+              userName: userName
+          ) )
+        }
+        print( "Creating user ${userName}" )
+        createUser( new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ) )
+
+        String policyName = "${namePrefix}policy1"
+        print( "Creating user policy ${policyName}" )
+        putUserPolicy( new PutUserPolicyRequest(
+            userName: userName,
+            policyName: policyName,
+            policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:ListBucket",
+                      "s3:ListBucketVersions"
+                    ],
+                    "Resource": "arn:aws:s3:::${bucketName}",
+                    "Condition": {
+                      "StringEquals": {
+                        "s3:prefix": [ "comma,", "dir/" ],
+                        "s3:delimiter": [ ",", "/" ]
+                      }
+                    }
+                  }
+                ]
+              }
+              """.stripIndent( )
+        ) )
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      getS3Client( userCredentials ).with {
+        print( "Listing objects for ${bucketName} with prefix dir/ and delimiter /" )
+        listObjects( new ListObjectsRequest( bucketName, 'dir/', null, '/', null ) ).with {
+          print( objectSummaries*.key )
+          assertTrue( objectSummaries.size( ) == 2, "Expected two objects but was: ${objectSummaries.size( )}" )
+        }
+
+        print( "Listing object versions for ${bucketName} with prefix comma, and delimiter ," )
+        listVersions( new ListVersionsRequest( bucketName, 'comma,', null, null, ',', null ) ).with {
+          print( versionSummaries*.key )
+          assertTrue( versionSummaries.size( ) == 2, "Expected two object versions but was: ${versionSummaries.size( )}" )
+        }
+
+        print( "Listing objects for ${bucketName} without prefix (should fail)" )
+        try { // Ensure fails with missing prefix
+          listObjects( new ListObjectsRequest( bucketName, null, null, '/', null ) )
+          assertTrue( false, "Expected failure due to missing delimiter" )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected failure: ${e}" )
+        }
+
+        print( "Listing objects for ${bucketName} with invalid prefix (should fail)" )
+        try { // Ensure fails with incorrect prefix
+          listObjects( new ListObjectsRequest( bucketName, 'invalid', null, '/', null ) )
+          assertTrue( false, "Expected failure due to incorrect delimiter" )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected failure: ${e}" )
+        }
+
+        print( "Listing objects for ${bucketName} with missing delimiter (should fail)" )
+        try { // Ensure fails with missing delimiter
+          listObjects( bucketName, 'dir' )
+          assertTrue( false, "Expected failure due to missing delimiter" )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected failure: ${e}" )
+        }
+
+        print( "Listing objects for ${bucketName} with invalid delimiter (should fail)" )
+        try { // Ensure fails with incorrect delimiter
+          listObjects( new ListObjectsRequest( bucketName, 'dir', null, '_', null ) )
+          assertTrue( false, "Expected failure due to incorrect delimiter" )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected failure: ${e}" )
+        }
+
+        void
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup" )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+
+  @Test
+  void testS3IAMConditionKeyPrefixAndPolicyVariablesTest( ) throws Exception {
+    final String namePrefix = UUID.randomUUID().toString().substring(0,8) + "-"
+    print( "Using resource prefix for test: ${namePrefix}" )
+
+    final List<Runnable> cleanupTasks = [] as List<Runnable>
+    String userName = "${namePrefix}user1"
+    String bucketName = "${namePrefix}bucket1"
+    try {
+      AWSCredentialsProvider adminCredentials = null
+      adminCredentials = getYouAreClient( credentials ).with {
+        // Create account to use for test
+        final String accountName = "${namePrefix}account1"
+        print("Creating test account: ${accountName}")
+        String adminAccountNumber = createAccount(new CreateAccountRequest(accountName: accountName)).with {
+          account?.accountId
+        }
+        assertTrue(adminAccountNumber != null, "Expected account number")
+        print("Created test account with number: ${adminAccountNumber}")
+        cleanupTasks.add {
+          print("Deleting test account: ${accountName}")
+          deleteAccount(new DeleteAccountRequest(accountName: accountName, recursive: true))
+        }
+
+        // Get credentials for admin account
+        print("Creating access key for test account admin user: ${accountName}")
+        YouAre adminIam = getYouAreClient( credentials )
+        adminIam.addRequestHandler(new AbstractRequestHandler() {
+          public void beforeRequest(final Request<?> request) {
+            request.addParameter("DelegateAccount", accountName)
+          }
+        })
+        adminCredentials = adminIam.with {
+          createAccessKey(new CreateAccessKeyRequest(userName: "admin")).with {
+            accessKey?.with {
+              new StaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretAccessKey))
+            }
+          }
+        }
+        assertTrue(adminCredentials != null, "Expected test acount admin user credentials")
+        print("Created test acount admin user access key: ${adminCredentials.credentials.AWSAccessKeyId}")
+
+        adminCredentials
+      }
+
+      AWSCredentialsProvider userCredentials = getYouAreClient( adminCredentials ).with {
+        cleanupTasks.add{
+          println( "Deleting user ${userName}" )
+          deleteUser( new DeleteUserRequest(
+              userName: userName
+          ) )
+        }
+        print( "Creating user ${userName}" )
+        createUser( new CreateUserRequest(
+            userName: userName,
+            path: '/'
+        ) )
+
+        String policyName = "${namePrefix}policy1"
+        print( "Creating user policy ${policyName}" )
+        putUserPolicy( new PutUserPolicyRequest(
+            userName: userName,
+            policyName: policyName,
+            policyDocument: """\
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "s3:ListAllMyBuckets",
+                      "s3:GetBucketLocation"
+                    ],
+                    "Resource": "arn:aws:s3:::*"
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": "s3:ListBucket",
+                    "Resource": "arn:aws:s3:::${bucketName}",
+                    "Condition": {"StringLike": {"s3:prefix": [
+                        "",
+                        "home/",
+                        "home/\${aws:username}/"
+                    ]}}
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": "s3:*",
+                    "Resource": [
+                      "arn:aws:s3:::${bucketName}/home/\${aws:username}",
+                      "arn:aws:s3:::${bucketName}/home/\${aws:username}/*"
+                    ]
+                  }
+                ]
+              }
+              """.stripIndent( )
+        ) )
+
+        cleanupTasks.add{
+          print( "Deleting user policy ${policyName}" )
+          deleteUserPolicy( new DeleteUserPolicyRequest(
+              userName: userName,
+              policyName: policyName
+          ) )
+        }
+
+        print( "Creating access key for user ${userName}" )
+        AWSCredentialsProvider userCredentials = createAccessKey( new CreateAccessKeyRequest(
+            userName: userName
+        ) ).with {
+          accessKey.with {
+            new StaticCredentialsProvider( new BasicAWSCredentials( accessKeyId, secretAccessKey ) )
+          }
+        }
+
+        cleanupTasks.add {
+          print( "Deleting access key for user ${userName}" )
+          deleteAccessKey( new DeleteAccessKeyRequest(
+              userName: userName,
+              accessKeyId: userCredentials.credentials.AWSAccessKeyId
+          ) )
+        }
+
+        userCredentials
+      }
+
+      getS3Client( adminCredentials ).with {
+        print( "Creating bucket ${bucketName}" )
+        createBucket( bucketName )
+
+        cleanupTasks.add{
+          print( "Deleting bucket ${bucketName}" )
+          deleteBucket( bucketName )
+        }
+      }
+
+      getS3Client( userCredentials ).with {
+        print( "Putting foo1 object to ${bucketName} home directory" )
+        putObject( bucketName, "home/${userName}/foo1", new ByteArrayInputStream( "DATA".getBytes( "utf-8" ) ), new ObjectMetadata( ) );
+
+        print( "Copying object foo1 to copy1 in ${bucketName} home directory" )
+        copyObject( bucketName, "home/${userName}/foo1", bucketName, "home/${userName}/copy1" );
+
+        [ null, '', 'home/', "home/${userName}/" ].each{ String prefix ->
+          print( "Listing bucket with prefix ${prefix?:'<NONE>'}" )
+          listObjects( new ListObjectsRequest(
+              bucketName: bucketName,
+              prefix: prefix
+          ) ).with {
+            objectSummaries?.each { final S3ObjectSummary summary ->
+              print( "- ${summary.key}" )
+            }
+          }
+        }
+
+        [ "/", 'nothome/', "nothome/${userName}/", 'home/otheruser/' ].each{ String prefix ->
+          print( "Listing bucket with prefix ${prefix?:'<NONE>'}, expect failure due to no permission for prefix" )
+          try {
+            listObjects( new ListObjectsRequest(
+                bucketName: bucketName,
+                prefix: prefix
+            ) )
+            assertThat( false, "Expected failure for listing objects with prefix ${prefix}" )
+          } catch ( AmazonServiceException e ) {
+            print( "Expected error listing objects for prefix ${prefix} without permission: ${e}" )
+          }
+        }
+
+        print( "Deleting object foo1 from ${bucketName} home directory" )
+        deleteObject( bucketName, "home/${userName}/foo1"  );
+
+        print( "Deleting object copy1 from ${bucketName} home directory" )
+        deleteObject( bucketName, "home/${userName}/copy1"  );
+
+        try {
+          print( "Putting object to ${bucketName} outside of home directory, should fail" )
+          putObject( bucketName, "foo1", new ByteArrayInputStream( "DATA".getBytes( "utf-8" ) ), new ObjectMetadata( ) );
+          assertThat( false, "Expected put object to fail for admin user due to permissions" )
+        } catch ( AmazonServiceException e ) {
+          print( "Expected error putting object without permission: ${e}" )
+        }
+
+        void
+      }
+
+      print( "Test complete" )
+    } finally {
+      // Attempt to clean up anything we created
+      cleanupTasks.reverseEach { Runnable cleanupTask ->
+        try {
+          cleanupTask.run()
+        } catch ( NoSuchEntityException e ) {
+          print( "Entity not found during cleanup." )
+        } catch ( AmazonServiceException e ) {
+          print( "Service error during cleanup; code: ${e.errorCode}, message: ${e.message}" )
+        } catch ( Exception e ) {
+          e.printStackTrace()
+        }
+      }
+    }
+  }
+}

--- a/eutester4j/ivy.xml
+++ b/eutester4j/ivy.xml
@@ -6,7 +6,17 @@
         <!-- core dependencies -->
         <dependency org="log4j" name="log4j" rev="1.2.17"/>
         <dependency org="org.testng" name="testng" rev="6.8.5"/>
-        <dependency org="com.amazonaws" name="aws-java-sdk" rev="1.8.9"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-autoscaling" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-cloudformation" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-cloudwatch" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-core" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-ec2" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-elasticloadbalancing" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-iam" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-simpleworkflow" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-sts" rev="1.10.+"/>
+        <dependency org="com.amazonaws" name="aws-java-sdk-s3" rev="1.10.+"/>
+        <dependency org="com.github.sjones4" name="you-are-sdk" rev="1.0.+"/>
         <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
         <dependency org="org.codehaus.groovy" name="groovy-all" rev="1.8.9"/>
 

--- a/eutester4j/ivysettings.xml
+++ b/eutester4j/ivysettings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ivysettings>
+  <settings defaultResolver="default"/>
+  <resolvers>
+    <ibiblio name="public"
+             m2compatible="true"
+             root="http://jcenter.bintray.com"/>
+  </resolvers>
+  <include url="${ivy.default.settings.dir}/ivysettings-shared.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-main-chain.xml"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-default-chain.xml"/>
+</ivysettings>


### PR DESCRIPTION
These changes are on top of those from pull 380.

These tests relate to the feature:

S3 IAM condition key support (s3:prefix, ...)
https://eucalyptus.atlassian.net/browse/EUCA-11010

and are mainly quick tests that could be run frequently, the exception being TestS3IAMConditionKeysForAclsAndGrants which takes ~1min.

The tests:

* TestS3IAMConditionKeyLocationConstraint
* TestS3IAMConditionKeysForAclsAndGrants

will not pass until a related S3 issue is fixed:

S3 location constraint ignored when creating bucket
https://eucalyptus.atlassian.net/browse/EUCA-11810
