### PR TITLE
SimpleWorkflow continue as new workflow coverage.

### DIFF
--- a/eutester4j/com/eucalyptus/tests/awssdk/TestSWFSuccessWorkflow.groovy
+++ b/eutester4j/com/eucalyptus/tests/awssdk/TestSWFSuccessWorkflow.groovy
@@ -19,9 +19,10 @@ import static com.eucalyptus.tests.awssdk.Eutester4j.SECRET_KEY;
 /**
  * This application tests SWF functionality for successful workflows.
  *
- * This is verification for the story:
+ * This is verification for the stories:
  *
  *   https://eucalyptus.atlassian.net/browse/EUCA-9619
+ *   https://eucalyptus.atlassian.net/browse/EUCA-12035
  */
 class TestSWFSuccessWorkflow {
 
@@ -89,10 +90,10 @@ class TestSWFSuccessWorkflow {
                 version: '1',
                 description: 'test activity type',
                 defaultTaskList: new TaskList(name: 'list'),
-                defaultTaskHeartbeatTimeout: '60',
-                defaultTaskScheduleToCloseTimeout: '60',
-                defaultTaskStartToCloseTimeout: '60',
-                defaultTaskScheduleToStartTimeout: '60'
+                defaultTaskHeartbeatTimeout: '180',
+                defaultTaskScheduleToCloseTimeout: '180',
+                defaultTaskStartToCloseTimeout: '180',
+                defaultTaskScheduleToStartTimeout: '180'
         ))
         cleanupTasks.add {
           print("Deprecating activity type ${domainName}")
@@ -108,8 +109,8 @@ class TestSWFSuccessWorkflow {
                 description: 'test workflow type',
                 defaultTaskList: new TaskList(name: 'list'),
                 defaultChildPolicy: 'TERMINATE',
-                defaultTaskStartToCloseTimeout: '60',
-                defaultExecutionStartToCloseTimeout: '60'
+                defaultTaskStartToCloseTimeout: '180',
+                defaultExecutionStartToCloseTimeout: '180'
         ))
         cleanupTasks.add {
           print("Deprecating workflow type ${domainName}")
@@ -155,8 +156,8 @@ class TestSWFSuccessWorkflow {
                 taskList: new TaskList(name: 'list'),
                 identity: 'test-decider-1'
         )).with {
-          assertThat( previousStartedEventId == 0, "Expected no previous started event" )
-          assertThat( startedEventId == 3, "Expected started event ID 3, but was ${startedEventId}" )
+          assertThat( previousStartedEventId == 0l, "Expected no previous started event" )
+          assertThat( startedEventId == 3l, "Expected started event ID 3, but was ${startedEventId}" )
           assertThat( taskToken != null, "Expected task token" )
           assertThat( workflowExecution != null, "Expected workflow execution ")
           assertThat( workflowExecution.runId == runId, "Expected workflow execution runId ${runId}, but was: ${workflowExecution.runId}")
@@ -170,7 +171,7 @@ class TestSWFSuccessWorkflow {
           Date currentTime = new Date( System.currentTimeMillis( ) + TimeUnit.MINUTES.toMillis( 5 ) ) // allow for some clock-skew
           events.get( 0 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 1, "Expected event ID 1, but was: ${eventId}" )
+            assertThat( eventId == 1l, "Expected event ID 1, but was: ${eventId}" )
             assertThat( eventType == 'WorkflowExecutionStarted', "Expected event type WorkflowExecutionStarted, but was: ${eventType}" )
             assertThat( workflowExecutionStartedEventAttributes != null, "Expected event attributes" )
             workflowExecutionStartedEventAttributes.with {
@@ -179,9 +180,9 @@ class TestSWFSuccessWorkflow {
               assertThat( workflowType != null, "Expected workflow type" )
               assertThat( workflowType.name == workflowTypeName, "Expected workflow type name ${workflowTypeName}, but was: ${workflowType.name}" )
               assertThat( workflowType.version == '1', "Expected workflow type version 1, but was: ${workflowType.version}" )
-              assertThat( executionStartToCloseTimeout == '60', "Expected exec start to close timeout 60, but was: ${executionStartToCloseTimeout}" )
-              assertThat( taskStartToCloseTimeout == '60', "Expected stask tart to close timeout 60, but was: ${taskStartToCloseTimeout}" )
-              assertThat( parentInitiatedEventId == 0, "Expected parent initiated event id 0, but was: ${parentInitiatedEventId}" )
+              assertThat( executionStartToCloseTimeout == '180', "Expected exec start to close timeout 180, but was: ${executionStartToCloseTimeout}" )
+              assertThat( taskStartToCloseTimeout == '180', "Expected stask tart to close timeout 180, but was: ${taskStartToCloseTimeout}" )
+              assertThat( parentInitiatedEventId == 0l, "Expected parent initiated event id 0, but was: ${parentInitiatedEventId}" )
               assertThat( input == 'input-here', "Expected input input-here, but was: ${input}" )
               assertThat( childPolicy == 'TERMINATE', "Expected child policy TERMINATE, but was: ${childPolicy}" )
               assertThat( tagList == ['tags', 'go', 'here'], "Expected tag list 'tags,go,here', but was: ${tagList}" )
@@ -189,23 +190,23 @@ class TestSWFSuccessWorkflow {
           }
           events.get( 1 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 2, "Expected event ID 2, but was: ${eventId}" )
+            assertThat( eventId == 2l, "Expected event ID 2, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskScheduled', "Expected event type DecisionTaskScheduled, but was: ${eventType}" )
             assertThat( decisionTaskScheduledEventAttributes != null, "Expected event attributes" )
             decisionTaskScheduledEventAttributes.with {
               assertThat( taskList != null, "Expected task list" )
               assertThat( taskList.name == 'list', "Expected task list 'list', but was: ${taskList.name}" )
-              assertThat( startToCloseTimeout == '60', "Expected start to close timeout 60, but was: ${startToCloseTimeout}" )
+              assertThat( startToCloseTimeout == '180', "Expected start to close timeout 180, but was: ${startToCloseTimeout}" )
             }
           }
           events.get( 2 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 3, "Expected event ID 3, but was: ${eventId}" )
+            assertThat( eventId == 3l, "Expected event ID 3, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskStarted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( decisionTaskStartedEventAttributes != null, "Expected event attributes" )
             decisionTaskStartedEventAttributes.with {
               assertThat( identity == 'test-decider-1', "Expected identity test-decider-1, but was: ${identity}" )
-              assertThat( scheduledEventId == 2, "Expected scheduled event Id 2, but was: ${scheduledEventId}" )
+              assertThat( scheduledEventId == 2l, "Expected scheduled event Id 2, but was: ${scheduledEventId}" )
             }
           }
           taskToken
@@ -246,7 +247,7 @@ class TestSWFSuccessWorkflow {
           assertThat( activityType.name == activityTypeName, "Expected activity type name ${activityTypeName}, but was: ${activityType.name}")
           assertThat( activityType.version == '1', "Expected activity type version 1, but was: ${activityType.version}")
           assertThat( activityId == 'activity-1', "Expected activity id activity-1, but was: ${activityId}")
-          assertThat( startedEventId == 6, "Expected started event ID 6, but was: ${startedEventId}")
+          assertThat( startedEventId == 6l, "Expected started event ID 6, but was: ${startedEventId}")
           assertThat( input == 'input', "Expected input input, but was: ${input}")
           taskToken
         }
@@ -263,8 +264,8 @@ class TestSWFSuccessWorkflow {
                 taskList: new TaskList(name: 'list'),
                 identity: 'test-decider-1'
         )).with {
-          assertThat( previousStartedEventId == 3, "Expected previous started event ID 3, but was: ${previousStartedEventId}" )
-          assertThat( startedEventId == 9, "Expected started event ID 9, but was ${startedEventId}" )
+          assertThat( previousStartedEventId == 3l, "Expected previous started event ID 3, but was: ${previousStartedEventId}" )
+          assertThat( startedEventId == 9l, "Expected started event ID 9, but was ${startedEventId}" )
           assertThat( taskToken != null, "Expected task token" )
           assertThat( workflowExecution != null, "Expected workflow execution ")
           assertThat( workflowExecution.runId == runId, "Expected workflow execution runId ${runId}, but was: ${workflowExecution.runId}")
@@ -279,36 +280,36 @@ class TestSWFSuccessWorkflow {
           // events 0-2 validated previously
           events.get( 0 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 1, "Expected event ID 1, but was: ${eventId}" )
+            assertThat( eventId == 1l, "Expected event ID 1, but was: ${eventId}" )
             assertThat( eventType == 'WorkflowExecutionStarted', "Expected event type WorkflowExecutionStarted, but was: ${eventType}" )
             assertThat( workflowExecutionStartedEventAttributes != null, "Expected event attributes" )
           }
           events.get( 1 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 2, "Expected event ID 2, but was: ${eventId}" )
+            assertThat( eventId == 2l, "Expected event ID 2, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskScheduled', "Expected event type DecisionTaskScheduled, but was: ${eventType}" )
             assertThat( decisionTaskScheduledEventAttributes != null, "Expected event attributes" )
           }
           events.get( 2 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 3, "Expected event ID 3, but was: ${eventId}" )
+            assertThat( eventId == 3l, "Expected event ID 3, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskStarted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( decisionTaskStartedEventAttributes != null, "Expected event attributes" )
           }
           events.get( 3 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 4, "Expected event ID 4, but was: ${eventId}" )
+            assertThat( eventId == 4l, "Expected event ID 4, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskCompleted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( decisionTaskCompletedEventAttributes != null, "Expected event attributes" )
             decisionTaskCompletedEventAttributes.with {
-              assertThat( scheduledEventId == 2, "Expected scheduled event Id 2, but was: ${scheduledEventId}" )
-              assertThat( startedEventId == 3, "Expected started event Id 3, but was: ${scheduledEventId}" )
+              assertThat( scheduledEventId == 2l, "Expected scheduled event Id 2, but was: ${scheduledEventId}" )
+              assertThat( startedEventId == 3l, "Expected started event Id 3, but was: ${scheduledEventId}" )
               assertThat( executionContext == 'foo', "Expected execution context foo, but was: ${executionContext}" )
             }
           }
           events.get( 4 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 5, "Expected event ID 5, but was: ${eventId}" )
+            assertThat( eventId == 5l, "Expected event ID 5, but was: ${eventId}" )
             assertThat( eventType == 'ActivityTaskScheduled', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( activityTaskScheduledEventAttributes != null, "Expected event attributes" )
             activityTaskScheduledEventAttributes.with {
@@ -318,7 +319,7 @@ class TestSWFSuccessWorkflow {
               assertThat( activityType.name == activityTypeName, "Expected activity type name ${activityTypeName}, but was: ${activityType.name}" )
               assertThat( activityType.version == '1', "Expected activity type version 1, but was: ${activityType.version}" )
               assertThat( activityId == 'activity-1', "Expected activity id activity-1, but was: ${activityId}" )
-              assertThat( decisionTaskCompletedEventId == 4, "Expected decision task completed event id 0, but was: ${decisionTaskCompletedEventId}" )
+              assertThat( decisionTaskCompletedEventId == 4l, "Expected decision task completed event id 0, but was: ${decisionTaskCompletedEventId}" )
               assertThat( input == 'input', "Expected input input, but was: ${input}" )
               assertThat( scheduleToStartTimeout == '120', "Expected schedule to start timeout 120, but was: ${scheduleToStartTimeout}" )
               assertThat( scheduleToCloseTimeout == '120', "Expected schedule to close timeout 120, but was: ${scheduleToCloseTimeout}" )
@@ -328,44 +329,120 @@ class TestSWFSuccessWorkflow {
           }
           events.get( 5 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 6, "Expected event ID 6, but was: ${eventId}" )
+            assertThat( eventId == 6l, "Expected event ID 6, but was: ${eventId}" )
             assertThat( eventType == 'ActivityTaskStarted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( activityTaskStartedEventAttributes != null, "Expected event attributes" )
             activityTaskStartedEventAttributes.with {
               assertThat( identity == 'test-activity-processor-1', "Expected identity test-activity-processor-1, but was: ${identity}" )
-              assertThat( scheduledEventId == 5, "Expected scheduled event Id 5, but was: ${scheduledEventId}" )
+              assertThat( scheduledEventId == 5l, "Expected scheduled event Id 5, but was: ${scheduledEventId}" )
             }
           }
           events.get( 6 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 7, "Expected event ID 7, but was: ${eventId}" )
+            assertThat( eventId == 7l, "Expected event ID 7, but was: ${eventId}" )
             assertThat( eventType == 'ActivityTaskCompleted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( activityTaskCompletedEventAttributes != null, "Expected event attributes" )
             activityTaskCompletedEventAttributes.with {
               assertThat( result == 'activity-1-result-here', "Expected result activity-1-result-here, but was: ${result}" )
-              assertThat( scheduledEventId == 5, "Expected scheduled event Id 5, but was: ${scheduledEventId}" )
-              assertThat( startedEventId == 6, "Expected started event Id 6, but was: ${scheduledEventId}" )
+              assertThat( scheduledEventId == 5l, "Expected scheduled event Id 5, but was: ${scheduledEventId}" )
+              assertThat( startedEventId == 6l, "Expected started event Id 6, but was: ${scheduledEventId}" )
             }
           }
           events.get( 7 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 8, "Expected event ID 8, but was: ${eventId}" )
+            assertThat( eventId == 8l, "Expected event ID 8, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskScheduled', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( decisionTaskScheduledEventAttributes != null, "Expected event attributes" )
             decisionTaskScheduledEventAttributes.with {
               assertThat( taskList != null, "Expected task list" )
               assertThat( taskList.name == 'list', "Expected task list 'list', but was: ${taskList.name}" )
-              assertThat( startToCloseTimeout == '60', "Expected start to close timeout 60, but was: ${startToCloseTimeout}" )
+              assertThat( startToCloseTimeout == '180', "Expected start to close timeout 180, but was: ${startToCloseTimeout}" )
             }
           }
           events.get( 8 ).with {
             assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
-            assertThat( eventId == 9, "Expected event ID 9, but was: ${eventId}" )
+            assertThat( eventId == 9l, "Expected event ID 9, but was: ${eventId}" )
             assertThat( eventType == 'DecisionTaskStarted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
             assertThat( decisionTaskStartedEventAttributes != null, "Expected event attributes" )
             decisionTaskStartedEventAttributes.with {
               assertThat( identity == 'test-decider-1', "Expected identity test-decider-1, but was: ${identity}" )
-              assertThat( scheduledEventId == 8, "Expected scheduled event Id 8, but was: ${scheduledEventId}" )
+              assertThat( scheduledEventId == 8l, "Expected scheduled event Id 8, but was: ${scheduledEventId}" )
+            }
+          }
+          taskToken
+        }
+
+        print( "Responding with continue as new workflow" )
+        respondDecisionTaskCompleted(new RespondDecisionTaskCompletedRequest(
+            taskToken: decisionTaskToken2,
+            decisions: [
+                new Decision( )
+                    .withDecisionType( DecisionType.ContinueAsNewWorkflowExecution )
+                    .withContinueAsNewWorkflowExecutionDecisionAttributes(
+                      new ContinueAsNewWorkflowExecutionDecisionAttributes(
+                          tagList: [ 'more', 'tags', 'here' ],
+                          taskList: new TaskList( name: 'list' ),
+                          input: 'more-input-here',
+                      )
+                    )
+            ]
+        ))
+
+        print( "Polling for decision task ${domainName}/list" )
+        String decisionTaskToken3 = pollForDecisionTask(new PollForDecisionTaskRequest(
+            domain: domainName,
+            taskList: new TaskList(name: 'list'),
+            identity: 'test-decider-1'
+        )).with {
+          assertThat(previousStartedEventId == 0l, "Expected previous started event ID 3, but was: ${previousStartedEventId}")
+          assertThat(taskToken != null, "Expected task token")
+          assertThat( workflowExecution != null, "Expected workflow execution ")
+          assertThat( workflowExecution.workflowId == workflowId, "Expected workflow execution workflowId ${workflowId}, but was: ${workflowExecution.workflowId}")
+          assertThat( workflowType != null, "Expected workflow type ")
+          assertThat( workflowType.name == workflowTypeName, "Expected workflow type name ${workflowTypeName}, but was: ${workflowType.name}")
+          assertThat( workflowType.version == '1', "Expected workflow type version 1, but was: ${workflowType.version}")
+          assertThat( events != null, "Expected events ")
+          print( events.toString( ) )
+          Date currentTime = new Date( System.currentTimeMillis( ) + TimeUnit.MINUTES.toMillis( 5 ) ) // allow for some clock-skew
+          events.get( 0 ).with {
+            assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
+            assertThat( eventId == 1l, "Expected event ID 1, but was: ${eventId}" )
+            assertThat( eventType == 'WorkflowExecutionStarted', "Expected event type WorkflowExecutionStarted, but was: ${eventType}" )
+            assertThat( workflowExecutionStartedEventAttributes != null, "Expected event attributes" )
+            workflowExecutionStartedEventAttributes.with {
+              assertThat( taskList != null, "Expected task list")
+              assertThat( taskList.name == 'list', "Expected task list 'list', but was: ${taskList.name}" )
+              assertThat( workflowType != null, "Expected workflow type" )
+              assertThat( workflowType.name == workflowTypeName, "Expected workflow type name ${workflowTypeName}, but was: ${workflowType.name}" )
+              assertThat( workflowType.version == '1', "Expected workflow type version 1, but was: ${workflowType.version}" )
+              assertThat( executionStartToCloseTimeout == '180', "Expected exec start to close timeout 180, but was: ${executionStartToCloseTimeout}" )
+              assertThat( taskStartToCloseTimeout == '180', "Expected stask tart to close timeout 180, but was: ${taskStartToCloseTimeout}" )
+              assertThat( parentInitiatedEventId == 0l, "Expected parent initiated event id 0, but was: ${parentInitiatedEventId}" )
+              assertThat( input == 'more-input-here', "Expected input input-here, but was: ${input}" )
+              assertThat( childPolicy == 'TERMINATE', "Expected child policy TERMINATE, but was: ${childPolicy}" )
+              assertThat( tagList == ['more', 'tags', 'here'], "Expected tag list 'more,tags,here', but was: ${tagList}" )
+              assertThat( continuedExecutionRunId == runId, "Expected continued execution run id ${runId}, but was: ${continuedExecutionRunId}" )
+            }
+          }
+          events.get( 1 ).with {
+            assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
+            assertThat( eventId == 2l, "Expected event ID 2, but was: ${eventId}" )
+            assertThat( eventType == 'DecisionTaskScheduled', "Expected event type DecisionTaskScheduled, but was: ${eventType}" )
+            assertThat( decisionTaskScheduledEventAttributes != null, "Expected event attributes" )
+            decisionTaskScheduledEventAttributes.with {
+              assertThat( taskList != null, "Expected task list" )
+              assertThat( taskList.name == 'list', "Expected task list 'list', but was: ${taskList.name}" )
+              assertThat( startToCloseTimeout == '180', "Expected start to close timeout 180, but was: ${startToCloseTimeout}" )
+            }
+          }
+          events.get( 2 ).with {
+            assertThat( currentTime.after( eventTimestamp ), "Expected event time in past" )
+            assertThat( eventId == 3l, "Expected event ID 3, but was: ${eventId}" )
+            assertThat( eventType == 'DecisionTaskStarted', "Expected event type DecisionTaskStarted, but was: ${eventType}" )
+            assertThat( decisionTaskStartedEventAttributes != null, "Expected event attributes" )
+            decisionTaskStartedEventAttributes.with {
+              assertThat( identity == 'test-decider-1', "Expected identity test-decider-1, but was: ${identity}" )
+              assertThat( scheduledEventId == 2l, "Expected scheduled event Id 2, but was: ${scheduledEventId}" )
             }
           }
           taskToken
@@ -373,7 +450,7 @@ class TestSWFSuccessWorkflow {
 
         print( "Responding workflow complete" );
         respondDecisionTaskCompleted(new RespondDecisionTaskCompletedRequest(
-                taskToken: decisionTaskToken2,
+                taskToken: decisionTaskToken3,
                 decisions: [
                         new Decision( )
                                 .withDecisionType( "CompleteWorkflowExecution" )
@@ -382,7 +459,6 @@ class TestSWFSuccessWorkflow {
                         )
                 ]
         ))
-
       }
 
       print( "Test complete" )


### PR DESCRIPTION
Updates TestSWFSuccessWorkflow with coverage of continue as new workflow functionality.

The timeouts used in the test are also updated to run reliably against AWS/SWF.

Related JIRA issue:
https://eucalyptus.atlassian.net/browse/EUCA-12035