### PR TITLE
Run sosreport on unique machine hostnames to improve performance

### DIFF
--- a/testcases/cloud_admin/run_sos_report.py
+++ b/testcases/cloud_admin/run_sos_report.py
@@ -86,7 +86,7 @@ class SOSreport(EutesterTestCase):
                     already_in_list = 1
             if not already_in_list:
                 newarray.append(machine)
-        return set(newarray)
+        return newarray
 
 if __name__ == "__main__":
     testcase = SOSreport()

--- a/testcases/cloud_admin/run_sos_report.py
+++ b/testcases/cloud_admin/run_sos_report.py
@@ -29,7 +29,7 @@ class SOSreport(EutesterTestCase):
         """
         This is where the test description goes
         """
-        for machine in self.tester.get_component_machines():
+        for machine in self.uniqify_component_machines():
             assert isinstance(machine, Machine)
             if machine.distro.name is "vmware":
                 continue
@@ -38,7 +38,7 @@ class SOSreport(EutesterTestCase):
 
     def Run(self):
         error_msg = ""
-        for machine in self.tester.get_component_machines():
+        for machine in self.uniqify_component_machines():
             try:
                 assert isinstance(machine, Machine)
                 if machine.distro.name is "vmware":
@@ -55,7 +55,7 @@ class SOSreport(EutesterTestCase):
 
     def Download(self):
         error_msg = ""
-        for machine in self.tester.get_component_machines():
+        for machine in self.uniqify_component_machines():
             assert isinstance(machine, Machine)
             if machine.distro.name is "vmware":
                 continue
@@ -75,6 +75,18 @@ class SOSreport(EutesterTestCase):
         self.Install()
         self.Run()
         self.Download()
+
+    def uniqify_component_machines(self):
+        newarray = []
+        all_machines = self.tester.get_component_machines()
+        for machine in all_machines:
+            already_in_list = 0
+            for item in newarray:
+                if machine.hostname == item.hostname:
+                    already_in_list = 1
+            if not already_in_list:
+                newarray.append(machine)
+        return set(newarray)
 
 if __name__ == "__main__":
     testcase = SOSreport()


### PR DESCRIPTION
De-duplicate the machine list when services are homed on the same
machine to run install/compress/download only once per unique
machine hostname.